### PR TITLE
Fixed the title entry in feed.rss of the blog

### DIFF
--- a/blog/feed.rss
+++ b/blog/feed.rss
@@ -4,7 +4,7 @@ layout: empty
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
 	<channel>
-		<title>{{ site.name }}</title>
+		<title>{{ site.title }}</title>
 		<description>{{ site.description }}</description>
 		<link>{{ site.url }}</link>
 		{% for post in site.posts limit:20 %}


### PR DESCRIPTION
The title section of the feed was not being populated, which
caused at least IFTTT to fail when attempting to read it.
