### PR TITLE
Permit links with `code` parts to be colored blue

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -83,7 +83,7 @@ td {
 /* blog posts */
 
 code {
-  color: black;
+  color: inherit;
   font-size: 1em;
   border: none;
   background: none;


### PR DESCRIPTION
It isn't clear in ["When can `Liskov` be lifted?"](http://typelevel.org/blog/2014/03/09/liskov_lifting.html) that many bits of code are links, due to the force-black color.  `inherit` here I think captures the intended meaning.
