### PR TITLE
New post: "Type members are [almost] type parameters"

### DIFF
--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -1,0 +1,235 @@
+---
+layout: post
+title: Type members are [almost] type parameters
+
+meta:
+  nav: blog
+  author: S11001001
+  pygments: true
+---
+
+Type members are [almost] type parameters
+=========================================
+
+Type members like `Member`
+
+```scala
+class Blah {
+  type Member
+}
+```
+
+and parameters like `Param`
+
+```scala
+class Blah2[Param]
+```
+
+have more similarities than differences.  The choice of which to use
+for a given situation is usually a matter of convenience.  In brief, a
+rule of thumb: **if you intend to use a parameter existentially in
+most cases, changing it to a member is probably better; a parameter is
+more convenient and harder to screw up in most circumstances**.
+
+We will discuss what on earth that means, among other things.  More
+broadly, though, in this series of articles on *Type Parameters and
+Type Members*, I want to tackle a variety of Scala types that look
+very different, but are really talking about the same thing, or
+almost.
+
+Two lists, all alike
+--------------------
+
+To illustrate, let's see two versions of the functional list.  It's
+typically not used existentially, so the usual choice of parameter
+over member fits our rule of thumb above.  It's instructive anyway, so
+let's see it.
+
+```scala
+sealed abstract class PList[T]
+final case class PNil[T]() extends Plist[T]
+final case class PCons[T](head: T, tail: PList[T])
+
+sealed abstract class MList {self =>
+  type T
+  def uncons: Option[MCons {type T = self.T}]
+}
+sealed abstract class MNil extends MList
+sealed abstract class MCons extends MList {self =>
+  val head: T
+  val tail: MList {type T = self.T}
+}
+```
+
+We're not quite done; we're missing a way to *make* `MNil`s and
+`MCons`es, which `PNil` and `PCons` have already provided for
+themselves, by virtue of being `case class`es.  But it's already
+pretty clear that a type parameter is a more straightforward way to
+define this data type.
+
+The instance creation takes just a bit more scaffolding for our
+examples:
+
+```scala
+def MNil[T0](): MNil {type T = T0} =
+  new MNil {
+    type T = T0
+  }
+
+def MCons[T0](hd: T0, tl: MList {type T = T0})
+  : MCons {type T = T0} =
+  new MCons {
+    type T = T0
+    val head = hd
+    val tail = tl
+  }
+```
+
+Why all the {type T = ...}?
+---------------------------
+
+After all, isn't the virtue of type members that we don't have to pass
+the type around everywhere?
+
+Let's see what happens with that theory.  Suppose we remove only one
+of the refinements above, the one in `val tail`, so `class MCons`
+looks like this:
+
+```scala
+sealed abstract class MCons extends MList {self =>
+  val head: T
+  val tail: MList
+}
+```
+
+Now let us put a couple members into the list, and add them together.
+
+```scala
+> val nums = MCons(2, MCons(3, MNil()))
+TODO
+
+> nums.head
+TODO
+
+> nums.tail.uncons.map(_.head)
+TODO ERROR
+```
+
+When we took the refinement off of `tail`, we eliminated any evidence
+about what its `type T` might be.  We only know that it must be *some
+type*.
+
+**In terms of type parameters, `MList` is like `PList[_]`, and `MList
+{type T = Int}` is like `PList[Int]`.** For the former, we say that
+the member, or parameter, is *existential*.
+
+When is existential OK?
+-----------------------
+
+Despite this limitation, there are functions that can be written on
+the existential version.  Here's the simplest:
+
+```scala
+def mlength(xs: MList): Int =
+  xs.uncons match {
+    case None => 0
+    case Some(c) => 1 + mlength(c.tail)
+  }
+```
+
+For the type parameter equivalent, the parameter on the argument is
+usually carried out or *lifted* to the function, like so:
+
+```scala
+def plength[T](xs: PList[T]): Int =
+  xs match {
+    case PNil() => 0
+    case PCons(_, t) => 1 + plength(t)
+  }
+```
+
+By the conversion rules above, though, we should be able to write an
+existential equivalent of `mlength`, and indeed we can:
+
+```scala
+def plength2(xs: PList[_]): Int =
+  xs match {
+    case PNil() => 0
+    case PCons(_, t) => 1 + plength2(t)
+  }
+```
+
+There's another simple rule we can follow when determining whether we
+can rewrite in an existential manner.
+
+1. When a type parameter appears only in one argument, and
+2. appears nowhere in the result type,
+
+we should always, ideally, be able to write the function in an
+existential manner.
+
+You can demonstrate this to yourself by having the parameterized
+variant (e.g. `plength`) call the existential variant, and, voilà, it
+compiles, so it must be right.
+
+This hints at what is usually, though not always, an advantage for
+type parameters: you have to ask for an existential, rather than
+silently getting one just because you forgot a refinement.  The
+mistake of `mdropFirst2`'s signature, to fail to relate the output
+type to the input type strongly enough, is an easy one to make when
+it's the default behavior.
+
+There is another mistake that type members open you up to. I have been
+using the very odd type parameter -- and member -- name `T`.  Java
+developers will find this choice very ordinary, but the name of choice
+in Scala is `A`.  So suppose I attempted to correct `mdropFirst2`'s
+type as follows:
+
+```scala
+def mdropFirst3[T0](xs: MList {type A = T0}) =
+  TODO copy definition
+```
+
+This method compiles, but I cannot invoke it!
+
+```scala
+> mdropFirst3(MNil[Int]())
+TODO error
+
+> mdropFirst3(MCons(42, MNil()))
+TODO error
+```
+
+That's because `MList {type A = T0}` is a perfectly reasonable
+intersection type: values of this type have *both* the type `MList` in
+their supertype tree somewhere, *and* a type member named `A`, which
+is bound to `T0`.  That `MList` has no such type member is irrelevant
+to the intersection and refinement of types in Scala.
+TODO implications of that
+
+Equivalence as a learning tool
+------------------------------
+
+Scala is large enough that very few understand all of it.  Moreover,
+there are many aspects of it that are poorly understood in general.
+
+So why focus on how different features are similar?  When we
+understand one area of Scala well, but another one poorly, we can form
+sensible ideas about the latter by drawing analogies with the former.
+This is how we solve problems with computers in general: we have an
+informal model in our heads, which we translate to a mathematical
+statement that a program can interpret, and it gives back a result
+that we can translate back to our informal model.
+
+My guess is that type parameters are much better understood than type
+members, but that existentials via type members are better understood
+than existentials introduced by `_` or `forSome`.  By knowing about
+equivalences and being able to discover more, you have a powerful tool
+for understanding unfamiliar aspects of Scala: just translate the
+problem back to what you know, and think about what it means there,
+because the conclusion will still hold when you translate it back.
+
+In this vein, we will next generalize the above rule about existential
+methods, discovering a simple tool for determining whether two method
+types *in general* are equivalent, and so that things you know about
+one easily carry over to the other.

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -11,6 +11,9 @@ meta:
 Type members are [almost] type parameters
 =========================================
 
+*This is the first of a series of articles on "Type Parameters and Type
+Members".*
+
 Type members like `Member`
 
 ```scala
@@ -218,3 +221,5 @@ types *in general* are equivalent, and so that things you know about
 one easily carry over to the other.  We will also explore methods that
 *cannot* be written in the existential style, at least under Scala's
 restrictions.
+
+*This article was tested with Scala 2.11.7.*

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -35,18 +35,19 @@ harder to screw up, but if you intend to use it existentially in most
 cases, changing it to a member is probably better**.
 
 Here, and in later posts, we will discuss what on earth that means,
-among other things.  More broadly, though, in this series of articles
-on *Type Parameters and Type Members*, I want to tackle a variety of
-Scala types that look very different, but are really talking about the
-same thing, or almost.
+among other things.  In this series of articles on *Type Parameters
+and Type Members*, I want to tackle a variety of Scala types that look
+very different, but are really talking about the same thing, or
+almost.
 
 Two lists, all alike
 --------------------
 
-To illustrate, let’s see two versions of the functional list.  It’s
-typically not used existentially, so the usual choice of parameter
-over member fits our rule of thumb above.  It’s instructive anyway, so
-let’s see it.
+To illustrate, let’s see two versions of
+[the functional list](http://www.artima.com/pins1ed/working-with-lists.html).
+Typically, it isn’t used existentially, so the usual choice of
+parameter over member fits our rule of thumb above.  It’s instructive
+anyway, so let’s see it.
 
 ```scala
 sealed abstract class PList[T]
@@ -70,8 +71,8 @@ sealed abstract class MCons extends MList {self =>
 We’re not quite done; we’re missing a way to *make* `MNil`s and
 `MCons`es, which `PNil` and `PCons` have already provided for
 themselves, by virtue of being `case class`es.  But it’s already
-pretty clear that a type parameter is a more straightforward way to
-define this data type.
+pretty clear that *a type parameter is a more straightforward way to
+define this particular data type*.
 
 The instance creation takes just a bit more scaffolding for our
 examples:
@@ -97,10 +98,11 @@ Why all the `{type T = ...}`?
 After all, isn’t the virtue of type members that we don’t have to pass
 the type around everywhere?
 
-Let’s see what happens with that theory.  Suppose we remove only one
-of the *refinement*s above, as these `{...}` rainclouds at the type
-level are called.  Let’s remove the one in `val tail`, so `class
-MCons` looks like this:
+Let’s see what happens when we attempt to apply that theory.  Suppose
+we remove only one of the
+[*refinement*s](http://www.scala-lang.org/files/archive/spec/2.11/03-types.html#compound-types)
+above, as these `{...}` rainclouds at the type level are called.
+Let’s remove the one in `val tail`, so `class MCons` looks like this:
 
 ```scala
 sealed abstract class MCons extends MList {self =>
@@ -131,7 +133,7 @@ scala> res3.map(_ - res2)
 ```
 
 When we took the refinement off of `tail`, we eliminated any evidence
-about what its `type T` might be.  We only know that it must be *some
+about what its `type T` might be.  We only know that *it must be some
 type*.  That’s what *existential* means.
 
 **In terms of type parameters, `MList` is like `PList[_]`, and `MList
@@ -141,8 +143,9 @@ the member, or parameter, is existential.
 When is existential OK?
 -----------------------
 
-Despite the limitation implied by the error above, there are functions
-that can be written on the existential version.  Here’s the simplest:
+Despite the limitation implied by the error above, there *are* useful
+functions that can be written on the existential version.  Here’s one
+of the simplest:
 
 ```scala
 def mlength(xs: MList): Int =
@@ -181,15 +184,16 @@ can rewrite in an existential manner.
 2. appears nowhere in the result type,
 
 we should always, ideally, be able to write the function in an
-existential manner.
+existential manner.  (We will discuss why it’s only “ideally” in the
+next article.)
 
 You can demonstrate this to yourself by having the parameterized
 variant (e.g. `plengthT`) call the existential variant
 (e.g. `plengthE`), and, voilà, it compiles, so it must be right.
 
-This hints at what is usually, though not always, an advantage for
+This hints at what is usually, though not always, **an advantage for
 type parameters: you have to ask for an existential, rather than
-silently getting one just because you forgot a refinement.  We will
+silently getting one just because you forgot a refinement**.  We will
 discuss what happens when you forget one in a later post.
 
 Equivalence as a learning tool
@@ -201,7 +205,7 @@ there are many aspects of it that are poorly understood in general.
 So why focus on how different features are similar?  When we
 understand one area of Scala well, but another one poorly, we can form
 sensible ideas about the latter by drawing analogies with the former.
-This is how we solve problems with computers in general: we have an
+This is how we solve problems with computers in general: we create an
 informal model in our heads, which we translate to a mathematical
 statement that a program can interpret, and it gives back a result
 that we can translate back to our informal model.
@@ -213,14 +217,14 @@ that neither form of existential is particularly well understood.
 
 By knowing about equivalences and being able to discover more, you
 have a powerful tool for understanding unfamiliar aspects of Scala:
-just translate the problem back to what you know, and think about what
+just translate the problem back to what you know and think about what
 it means there, because the conclusion will still hold when you
-translate it back.  (Category theorists, eat your hearts out.)
+translate it forward.  (Category theorists, eat your hearts out.)
 
 In this vein, we will next generalize the above rule about existential
 methods, discovering a simple tool for determining whether two method
-types *in general* are equivalent, and so that things you know about
-one easily carry over to the other.  We will also explore methods that
+types *in general* are equivalent, whereby things you know about one
+easily carry over to the other.  We will also explore methods that
 *cannot* be written in the existential style, at least under Scala’s
 restrictions.
 

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -215,4 +215,6 @@ because the conclusion will still hold when you translate it back.
 In this vein, we will next generalize the above rule about existential
 methods, discovering a simple tool for determining whether two method
 types *in general* are equivalent, and so that things you know about
-one easily carry over to the other.
+one easily carry over to the other.  We will also explore methods that
+*cannot* be written in the existential style, at least under Scala's
+restrictions.

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -208,8 +208,13 @@ That's because `MList {type A = T0}` is a perfectly reasonable
 intersection type: values of this type have *both* the type `MList` in
 their supertype tree somewhere, *and* a type member named `A`, which
 is bound to `T0`.  That `MList` has no such type member is irrelevant
-to the intersection and refinement of types in Scala.
-TODO implications of that
+to the intersection and refinement of types in Scala.  This type means
+"an instance of the trait `MList`, with a type member named `A` set to
+`T0`".  This type member `A` could come from another trait mixed with
+`Mlist` or an inline subclass.  Whether such a thing is impossible to
+instantiate -- due to `sealed`, `final`, or anything else -- is also
+irrelevant; types with no values are meaningful and useful in both
+Java and Scala.
 
 Equivalence as a learning tool
 ------------------------------

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -95,8 +95,9 @@ After all, isn't the virtue of type members that we don't have to pass
 the type around everywhere?
 
 Let's see what happens with that theory.  Suppose we remove only one
-of the refinements above, the one in `val tail`, so `class MCons`
-looks like this:
+of the *refinement*s above, as these `{...}` rainclouds at the type
+level are called.  Let's remove the one in `val tail`, so `class
+MCons` looks like this:
 
 ```scala
 sealed abstract class MCons extends MList {self =>

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -30,13 +30,13 @@ class Blah2[Param]
 
 have more similarities than differences.  The choice of which to use
 for a given situation is usually a matter of convenience.  In brief, a
-rule of thumb: **a type parameter is usually more convenient and
-harder to screw up, but if you intend to use it existentially in most
+rule of thumb: **a type parameter is usually more convenient and
+harder to screw up, but if you intend to use it existentially in most
 cases, changing it to a member is probably better**.
 
 Here, and in later posts, we will discuss what on earth that means,
-among other things.  In this series of articles on *Type Parameters
-and Type Members*, I want to tackle a variety of Scala types that look
+among other things.  In this series of articles on *Type Parameters
+and Type Members*, I want to tackle a variety of Scala types that look
 very different, but are really talking about the same thing, or
 almost.
 
@@ -44,7 +44,7 @@ Two lists, all alike
 --------------------
 
 To illustrate, let’s see two versions of
-[the functional list](http://www.artima.com/pins1ed/working-with-lists.html).
+[the functional list](http://www.artima.com/pins1ed/working-with-lists.html).
 Typically, it isn’t used existentially, so the usual choice of
 parameter over member fits our rule of thumb above.  It’s instructive
 anyway, so let’s see it.
@@ -69,10 +69,10 @@ sealed abstract class MCons extends MList {self =>
 ```
 
 We’re not quite done; we’re missing a way to *make* `MNil`s and
-`MCons`es, which `PNil` and `PCons` have already provided for
-themselves, by virtue of being `case class`es.  But it’s already
+`MCons`es, which `PNil` and `PCons` have already provided
+for themselves, by virtue of being `case class`es.  But it’s already
 pretty clear that *a type parameter is a more straightforward way to
-define this particular data type*.
+define this particular data type*.
 
 The instance creation takes just a bit more scaffolding for our
 examples:
@@ -133,7 +133,7 @@ scala> res3.map(_ - res2)
 ```
 
 When we took the refinement off of `tail`, we eliminated any evidence
-about what its `type T` might be.  We only know that *it must be some
+about what its `type T` might be.  We only know that *it must be some
 type*.  That’s what *existential* means.
 
 **In terms of type parameters, `MList` is like `PList[_]`, and `MList
@@ -144,7 +144,7 @@ When is existential OK?
 -----------------------
 
 Despite the limitation implied by the error above, there *are* useful
-functions that can be written on the existential version.  Here’s one
+functions that can be written on the existential version.  Here’s one
 of the simplest:
 
 ```scala
@@ -155,7 +155,7 @@ def mlength(xs: MList): Int =
   }
 ```
 
-For the type parameter equivalent, the parameter on the argument is
+For the type parameter equivalent, the parameter on the argument is
 usually carried out or *lifted* to the function, like so:
 
 ```scala
@@ -167,7 +167,7 @@ def plengthT[T](xs: PList[T]): Int =
 ```
 
 By the conversion rules above, though, we should be able to write an
-existential equivalent of `mlength` for `PList`, and indeed we can:
+existential equivalent of `mlength` for `PList`, and indeed we can:
 
 ```scala
 def plengthE(xs: PList[_]): Int =
@@ -178,13 +178,13 @@ def plengthE(xs: PList[_]): Int =
 ```
 
 There’s another simple rule we can follow when determining whether we
-can rewrite in an existential manner.
+can rewrite in an existential manner.
 
 1. When a type parameter appears only in one argument, and
 2. appears nowhere in the result type,
 
 we should always, ideally, be able to write the function in an
-existential manner.  (We will discuss why it’s only “ideally” in the
+existential manner.  (We will discuss why it’s only “ideally” in the
 next article.)
 
 You can demonstrate this to yourself by having the parameterized
@@ -202,30 +202,30 @@ Equivalence as a learning tool
 Scala is large enough that very few understand all of it.  Moreover,
 there are many aspects of it that are poorly understood in general.
 
-So why focus on how different features are similar?  When we
+So why focus on how different features are similar?  When we
 understand one area of Scala well, but another one poorly, we can form
 sensible ideas about the latter by drawing analogies with the former.
 This is how we solve problems with computers in general: we create an
-informal model in our heads, which we translate to a mathematical
-statement that a program can interpret, and it gives back a result
-that we can translate back to our informal model.
+informal model in our heads, which we translate to a
+mathematical statement that a program can interpret, and it gives back
+a result that we can translate back to our informal model.
 
 My guess is that type parameters are much better understood than type
-members, but that existentials via type members are better understood
-than existentials introduced by `_` or `forSome`, though I’d wager
+members, but that existentials via type members are better understood
+than existentials introduced by `_` or `forSome`, though I’d wager
 that neither form of existential is particularly well understood.
 
 By knowing about equivalences and being able to discover more, you
 have a powerful tool for understanding unfamiliar aspects of Scala:
 just translate the problem back to what you know and think about what
 it means there, because the conclusion will still hold when you
-translate it forward.  (Category theorists, eat your hearts out.)
+translate it forward.  (Category theorists, eat your hearts out.)
 
 In this vein, we will next generalize the above rule about existential
-methods, discovering a simple tool for determining whether two method
-types *in general* are equivalent, whereby things you know about one
-easily carry over to the other.  We will also explore methods that
-*cannot* be written in the existential style, at least under Scala’s
-restrictions.
+methods, discovering a simple tool for determining whether two
+method types *in general* are equivalent, whereby things you know
+about one easily carry over to the other.  We will also explore
+methods that *cannot* be written in the existential style, at least
+under Scala’s restrictions.
 
 *This article was tested with Scala 2.11.7.*

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -208,12 +208,14 @@ that we can translate back to our informal model.
 
 My guess is that type parameters are much better understood than type
 members, but that existentials via type members are better understood
-than existentials introduced by `_` or `forSome`.  By knowing about
-equivalences and being able to discover more, you have a powerful tool
-for understanding unfamiliar aspects of Scala: just translate the
-problem back to what you know, and think about what it means there,
-because the conclusion will still hold when you translate it back.
-(Category theorists, eat your hearts out.)
+than existentials introduced by `_` or `forSome`, though I’d wager
+that neither form of existential is particularly well understood.
+
+By knowing about equivalences and being able to discover more, you
+have a powerful tool for understanding unfamiliar aspects of Scala:
+just translate the problem back to what you know, and think about what
+it means there, because the conclusion will still hold when you
+translate it back.  (Category theorists, eat your hearts out.)
 
 In this vein, we will next generalize the above rule about existential
 methods, discovering a simple tool for determining whether two method

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -132,17 +132,17 @@ scala> res3.map(_ - res2)
 
 When we took the refinement off of `tail`, we eliminated any evidence
 about what its `type T` might be.  We only know that it must be *some
-type*.
+type*.  That’s what *existential* means.
 
 **In terms of type parameters, `MList` is like `PList[_]`, and `MList
-{type T = Int}` is like `PList[Int]`.** For the former, we say that
-the member, or parameter, is *existential*.
+{type T = Int}` is like `PList[Int]`.**  For the former, we say that
+the member, or parameter, is existential.
 
 When is existential OK?
 -----------------------
 
-Despite this limitation, there are functions that can be written on
-the existential version.  Here's the simplest:
+Despite the limitation implied by the error above, there are functions
+that can be written on the existential version.  Here’s the simplest:
 
 ```scala
 def mlength(xs: MList): Int =

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -48,7 +48,7 @@ let's see it.
 ```scala
 sealed abstract class PList[T]
 final case class PNil[T]() extends PList[T]
-final case class PCons[T](head: T, tail: PList[T])
+final case class PCons[T](head: T, tail: PList[T]) extends PList[T]
 
 sealed abstract class MList {self =>
   type T

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -11,8 +11,8 @@ meta:
 Type members are [almost] type parameters
 =========================================
 
-*This is the first of a series of articles on "Type Parameters and Type
-Members".*
+*This is the first of a series of articles on “Type Parameters and Type
+Members”.*
 
 Type members like `Member`
 
@@ -34,19 +34,19 @@ rule of thumb: **if you intend to use a parameter existentially in
 most cases, changing it to a member is probably better; a parameter is
 more convenient and harder to screw up in most circumstances**.
 
-We will discuss what on earth that means, among other things.  More
-broadly, though, in this series of articles on *Type Parameters and
-Type Members*, I want to tackle a variety of Scala types that look
-very different, but are really talking about the same thing, or
-almost.
+Here, and in later posts, we will discuss what on earth that means,
+among other things.  More broadly, though, in this series of articles
+on *Type Parameters and Type Members*, I want to tackle a variety of
+Scala types that look very different, but are really talking about the
+same thing, or almost.
 
 Two lists, all alike
 --------------------
 
-To illustrate, let's see two versions of the functional list.  It's
+To illustrate, let’s see two versions of the functional list.  It’s
 typically not used existentially, so the usual choice of parameter
-over member fits our rule of thumb above.  It's instructive anyway, so
-let's see it.
+over member fits our rule of thumb above.  It’s instructive anyway, so
+let’s see it.
 
 ```scala
 sealed abstract class PList[T]
@@ -67,9 +67,9 @@ sealed abstract class MCons extends MList {self =>
 }
 ```
 
-We're not quite done; we're missing a way to *make* `MNil`s and
+We’re not quite done; we’re missing a way to *make* `MNil`s and
 `MCons`es, which `PNil` and `PCons` have already provided for
-themselves, by virtue of being `case class`es.  But it's already
+themselves, by virtue of being `case class`es.  But it’s already
 pretty clear that a type parameter is a more straightforward way to
 define this data type.
 
@@ -91,15 +91,15 @@ def MCons[T0](hd: T0, tl: MList {type T = T0})
   }
 ```
 
-Why all the {type T = ...}?
----------------------------
+Why all the `{type T = ...}`?
+-----------------------------
 
-After all, isn't the virtue of type members that we don't have to pass
+After all, isn’t the virtue of type members that we don’t have to pass
 the type around everywhere?
 
-Let's see what happens with that theory.  Suppose we remove only one
+Let’s see what happens with that theory.  Suppose we remove only one
 of the *refinement*s above, as these `{...}` rainclouds at the type
-level are called.  Let's remove the one in `val tail`, so `class
+level are called.  Let’s remove the one in `val tail`, so `class
 MCons` looks like this:
 
 ```scala
@@ -164,7 +164,7 @@ def plength[T](xs: PList[T]): Int =
 ```
 
 By the conversion rules above, though, we should be able to write an
-existential equivalent of `mlength`, and indeed we can:
+existential equivalent of `mlength` for `PList`, and indeed we can:
 
 ```scala
 def plength2(xs: PList[_]): Int =
@@ -174,7 +174,7 @@ def plength2(xs: PList[_]): Int =
   }
 ```
 
-There's another simple rule we can follow when determining whether we
+There’s another simple rule we can follow when determining whether we
 can rewrite in an existential manner.
 
 1. When a type parameter appears only in one argument, and
@@ -219,7 +219,7 @@ In this vein, we will next generalize the above rule about existential
 methods, discovering a simple tool for determining whether two method
 types *in general* are equivalent, and so that things you know about
 one easily carry over to the other.  We will also explore methods that
-*cannot* be written in the existential style, at least under Scala's
+*cannot* be written in the existential style, at least under Scala’s
 restrictions.
 
 *This article was tested with Scala 2.11.7.*

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -60,7 +60,7 @@ sealed abstract class MNil extends MList {
 sealed abstract class MCons extends MList {self =>
   val head: T
   val tail: MList {type T = self.T}
-  def uncons = Some(self)
+  def uncons = Some(self: MCons {type T = self.T})
 }
 ```
 
@@ -109,14 +109,22 @@ sealed abstract class MCons extends MList {self =>
 Now let us put a couple members into the list, and add them together.
 
 ```scala
-> val nums = MCons(2, MCons(3, MNil()))
-TODO
+scala> val nums = MCons(2, MCons(3, MNil())): MCons{type T = Int}
+nums: tmtp.MCons{type T = Int} = tmtp.MList$$anon$2@3c649f69
 
-> nums.head
-TODO
+scala> nums.head
+res1: nums.T = 2
 
-> nums.tail.uncons.map(_.head)
-TODO ERROR
+scala> res1 + res1
+res2: Int = 4
+
+scala> nums.tail.uncons.map(_.head)
+res3: Option[nums.tail.T] = Some(3)
+
+scala> res3.map(_ - res2)
+<console>:21: error: value - is not a member of nums.tail.T
+       res3.map(_ - res2)
+                  ^
 ```
 
 When we took the refinement off of `tail`, we eliminated any evidence

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -237,6 +237,7 @@ equivalences and being able to discover more, you have a powerful tool
 for understanding unfamiliar aspects of Scala: just translate the
 problem back to what you know, and think about what it means there,
 because the conclusion will still hold when you translate it back.
+(Category theorists, eat your hearts out.)
 
 In this vein, we will next generalize the above rule about existential
 methods, discovering a simple tool for determining whether two method

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -30,9 +30,9 @@ class Blah2[Param]
 
 have more similarities than differences.  The choice of which to use
 for a given situation is usually a matter of convenience.  In brief, a
-rule of thumb: **if you intend to use a parameter existentially in
-most cases, changing it to a member is probably better; a parameter is
-more convenient and harder to screw up in most circumstances**.
+rule of thumb: **a type parameter is usually more convenient and
+harder to screw up, but if you intend to use it existentially in most
+cases, changing it to a member is probably better**.
 
 Here, and in later posts, we will discuss what on earth that means,
 among other things.  More broadly, though, in this series of articles

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -186,43 +186,8 @@ compiles, so it must be right.
 
 This hints at what is usually, though not always, an advantage for
 type parameters: you have to ask for an existential, rather than
-silently getting one just because you forgot a refinement.  The
-mistake of `mdropFirst2`'s signature, to fail to relate the output
-type to the input type strongly enough, is an easy one to make when
-it's the default behavior.
-
-There is another mistake that type members open you up to. I have been
-using the very odd type parameter -- and member -- name `T`.  Java
-developers will find this choice very ordinary, but the name of choice
-in Scala is `A`.  So suppose I attempted to correct `mdropFirst2`'s
-type as follows:
-
-```scala
-def mdropFirst3[T0](xs: MList {type A = T0}) =
-  TODO copy definition
-```
-
-This method compiles, but I cannot invoke it!
-
-```scala
-> mdropFirst3(MNil[Int]())
-TODO error
-
-> mdropFirst3(MCons(42, MNil()))
-TODO error
-```
-
-That's because `MList {type A = T0}` is a perfectly reasonable
-intersection type: values of this type have *both* the type `MList` in
-their supertype tree somewhere, *and* a type member named `A`, which
-is bound to `T0`.  That `MList` has no such type member is irrelevant
-to the intersection and refinement of types in Scala.  This type means
-"an instance of the trait `MList`, with a type member named `A` set to
-`T0`".  This type member `A` could come from another trait mixed with
-`MList` or an inline subclass.  Whether such a thing is impossible to
-instantiate -- due to `sealed`, `final`, or anything else -- is also
-irrelevant; types with no values are meaningful and useful in both
-Java and Scala.
+silently getting one just because you forgot a refinement.  We will
+discuss what happens when you forget one in a later post.
 
 Equivalence as a learning tool
 ------------------------------

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -47,7 +47,7 @@ let's see it.
 
 ```scala
 sealed abstract class PList[T]
-final case class PNil[T]() extends Plist[T]
+final case class PNil[T]() extends PList[T]
 final case class PCons[T](head: T, tail: PList[T])
 
 sealed abstract class MList {self =>
@@ -211,7 +211,7 @@ is bound to `T0`.  That `MList` has no such type member is irrelevant
 to the intersection and refinement of types in Scala.  This type means
 "an instance of the trait `MList`, with a type member named `A` set to
 `T0`".  This type member `A` could come from another trait mixed with
-`Mlist` or an inline subclass.  Whether such a thing is impossible to
+`MList` or an inline subclass.  Whether such a thing is impossible to
 instantiate -- due to `sealed`, `final`, or anything else -- is also
 irrelevant; types with no values are meaningful and useful in both
 Java and Scala.

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -54,10 +54,13 @@ sealed abstract class MList {self =>
   type T
   def uncons: Option[MCons {type T = self.T}]
 }
-sealed abstract class MNil extends MList
+sealed abstract class MNil extends MList {
+  def uncons = None
+}
 sealed abstract class MCons extends MList {self =>
   val head: T
   val tail: MList {type T = self.T}
+  def uncons = Some(self)
 }
 ```
 

--- a/_posts/2015-07-13-type-members-parameters.md
+++ b/_posts/2015-07-13-type-members-parameters.md
@@ -156,10 +156,10 @@ For the type parameter equivalent, the parameter on the argument is
 usually carried out or *lifted* to the function, like so:
 
 ```scala
-def plength[T](xs: PList[T]): Int =
+def plengthT[T](xs: PList[T]): Int =
   xs match {
     case PNil() => 0
-    case PCons(_, t) => 1 + plength(t)
+    case PCons(_, t) => 1 + plengthT(t)
   }
 ```
 
@@ -167,10 +167,10 @@ By the conversion rules above, though, we should be able to write an
 existential equivalent of `mlength` for `PList`, and indeed we can:
 
 ```scala
-def plength2(xs: PList[_]): Int =
+def plengthE(xs: PList[_]): Int =
   xs match {
     case PNil() => 0
-    case PCons(_, t) => 1 + plength2(t)
+    case PCons(_, t) => 1 + plengthE(t)
   }
 ```
 
@@ -184,8 +184,8 @@ we should always, ideally, be able to write the function in an
 existential manner.
 
 You can demonstrate this to yourself by having the parameterized
-variant (e.g. `plength`) call the existential variant, and, voilà, it
-compiles, so it must be right.
+variant (e.g. `plengthT`) call the existential variant
+(e.g. `plengthE`), and, voilà, it compiles, so it must be right.
 
 This hints at what is usually, though not always, an advantage for
 type parameters: you have to ask for an existential, rather than


### PR DESCRIPTION
First in a series on type parameters and members, for posting on July 13.