### PR TITLE
Clarify "community staff" in CoC

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -24,7 +24,7 @@ Community staff will be happy to help participants contact local law enforcement
 
 We expect participants to follow these rules at all community venues (including online venues) and social events associated with the community.
 
-For any questions or with any concerns at all, please contact any member of community staff. Specifically, you can contact:
+If you have any questions or concerns, please contact a member of the community staff, such as:
 * [Miles Sabin](mailto:%6d%69%6c%65%73@%6d%69%6c%65%73%73%61%62%69%6e.%63%6f%6d)
 * [Erik Osheim](mailto:d_m@plastic-idolatry.com)
 * [Stew O'Connor](mailto:%73%74%65%77@%76%69%72%65%6f.%6f%72%67)

--- a/conduct.md
+++ b/conduct.md
@@ -24,7 +24,12 @@ Community staff will be happy to help participants contact local law enforcement
 
 We expect participants to follow these rules at all community venues (including online venues) and social events associated with the community.
 
-For any questions or with any concerns at all, please contact any member of community staff.
+For any questions or with any concerns at all, please contact any member of community staff. Specifically, you can contact:
+* [Miles Sabin](mailto:%6d%69%6c%65%73@%6d%69%6c%65%73%73%61%62%69%6e.%63%6f%6d)
+* [Erik Osheim](mailto:d_m@plastic-idolatry.com)
+* [Stew O'Connor](mailto:%73%74%65%77@%76%69%72%65%6f.%6f%72%67)
+* [Cody Allen](mailto:%63%65%65%64%75%62%73@%67%6d%61%69%6c.%63%6f%6d)
+* Any other [members of the typelevel organization](https://github.com/orgs/typelevel/people).
 
 
 _This CoC was adapted from [haskellnow.org](http://www.haskellnow.org), which is inspired from [Geek Feminism](http://geekfeminism.wikia.com/wiki/Event_Guidelines)._


### PR DESCRIPTION
This is a first pass at a resolution to #33.

I've added email links for a few people that already had their email
addresses publicly available and that I felt confident would be happy to
be on this contact list. We can definitely add more contacts if there
are others who would be willing to be contacts.