### PR TITLE
Changes in the website to modify Lambda.World Conference and add a C4P for unconference

### DIFF
--- a/_events/2016-09-30-conf-cadiz.md
+++ b/_events/2016-09-30-conf-cadiz.md
@@ -13,6 +13,12 @@ poster_thumb: "/img/media/cadiz-thumb.jpg"
 location_section: true
 sponsors_section: true
 
+schedule:
+
+  - time: "--:--"
+    title: "Your proposal can be the first! :-)"
+
+
 sponsors:
   - name: "47 Degrees"
     logo: "/img/media/sponsors/47_degrees.png"
@@ -25,7 +31,19 @@ sponsors:
 ## About the Conference
 
 A day of Typelevel sessions, co-located with [Lambda World](http://www.lambda.world).
-Stay tuned for details!
+
+On Friday, September 30th,[Lambda World](http://www.lambda.world) will host a Typelevel Unconference during the morning and a few workshops in the afternoon. The day will conclude with a community dinner where attendees can discuss functional concepts while enjoying Flamenco music.
+
+If you're interested in speaking during the Unconference, please send your proposals. We will publish all the submitted talks on the website for review.
+
+<a class="typeform-share btn large" href="https://jorgegalindocruces.typeform.com/to/dTlYCv" data-mode="2" target="_blank">Send your Proposal</a>
+<script>(function(){var qs,js,q,s,d=document,gi=d.getElementById,ce=d.createElement,gt=d.getElementsByTagName,id='typef_orm',b='https://s3-eu-west-1.amazonaws.com/share.typeform.com/';if(!gi.call(d,id)){js=ce.call(d,'script');js.id=id;js.src=b+'share.js';q=gt.call(d,'script')[0];q.parentNode.insertBefore(js,q)}id=id+'_';if(!gi.call(d,id)){qs=ce.call(d,'link');qs.rel='stylesheet';qs.id=id;qs.href=b+'share-button.css';s=gt.call(d,'head')[0];s.appendChild(qs,s)}})()</script>
+
+
+## Talks proposals
+
+{% assign schedule=page.schedule %}
+{% include schedule.html %}
 
 ## Venue
 

--- a/_events/2016-09-30-conf-cadiz.md
+++ b/_events/2016-09-30-conf-cadiz.md
@@ -34,7 +34,7 @@ A day of Typelevel sessions, co-located with [Lambda World](http://www.lambda.wo
 
 On Friday, September 30th,[Lambda World](http://www.lambda.world) will host a Typelevel Unconference during the morning and a few workshops in the afternoon. The day will conclude with a community dinner where attendees can discuss functional concepts while enjoying Flamenco music.
 
-If you're interested in speaking during the Unconference, please send your proposals. We will publish all the submitted talks on the website for review.
+If you're interested in speaking during the unconference, please send us your ideas. This is just to see what people are interested in. There is no review, the actual sessions are decided at the conference! We will publish all the submitted proposals here.
 
 <a class="typeform-share btn large" href="https://jorgegalindocruces.typeform.com/to/dTlYCv" data-mode="2" target="_blank">Send your Proposal</a>
 <script>(function(){var qs,js,q,s,d=document,gi=d.getElementById,ce=d.createElement,gt=d.getElementsByTagName,id='typef_orm',b='https://s3-eu-west-1.amazonaws.com/share.typeform.com/';if(!gi.call(d,id)){js=ce.call(d,'script');js.id=id;js.src=b+'share.js';q=gt.call(d,'script')[0];q.parentNode.insertBefore(js,q)}id=id+'_';if(!gi.call(d,id)){qs=ce.call(d,'link');qs.rel='stylesheet';qs.id=id;qs.href=b+'share-button.css';s=gt.call(d,'head')[0];s.appendChild(qs,s)}})()</script>


### PR DESCRIPTION
- Added complete description of the conference
- Added empty talks proposals list (the idea is having it updated with the new proposals and sharing it by Twitter)
- Added a button for C4P, please @larsrh , can you review it? I don't know if this is the better way to do it. This is the platform that we use to do it Lambda.World (Typeform). Non invasive and with responsive design.

Thanks!