### PR TITLE
Update head to include the RSS link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,7 @@
 
     <link rel="mask-icon" href="{{ site.baseurl }}/img/favicon-safari.svg" color="#F51C2B">
     <link href="{{ site.baseurl }}/img/favicon.png" rel="icon" type="image/x-icon">
+    <link rel="alternate" href="{{ site.baseurl }}/blog/feed.rss" title="RSS feed" type="application/rss+xml">
 
     <!-- Custom CSS -->
     <link rel="stylesheet" href="/css/main.css">


### PR DESCRIPTION
The RSS feed is not automatically discoverable because the <head> section does not indicate it. And it should, it makes discovery easier - for example Firefox's "Subscribe to this page" button does not work without it.