### PR TITLE
Add code of conduct section and links to Summit events

### DIFF
--- a/_events/2017-03-23-summit-nyc.md
+++ b/_events/2017-03-23-summit-nyc.md
@@ -27,6 +27,8 @@ The Summits are open to all, not just current contributors to and users of the T
 Whilst many of the Typelevel projects use somewhat "advanced" Scala, they are a lot more approachable than many people think, and a major part of Typelevel's mission is to make the ideas they embody much more widely accessible.
 If you're interested in types and pure functional programming we'd love to see you here!
 
+This is a community conference and we strive to make it an inclusive and fulfilling event for all participants. All attendees, speakers, and organizers must abide by the [Typelevel Code of Conduct](http://typelevel.org/conduct.html).
+
 ## Tickets
 
 This year, we're offering a combined ticket for both NE Scala and the Summit.
@@ -72,7 +74,3 @@ For more information about the venue and accommodation, check out the [NE Scala 
 If you would like to talk to us about sponsorship options, please get in touch with us:
 
 <a class="btn large" href="mailto:info@typelevel.org">Become a sponsor</a>
-
-## Code of Conduct
-
-The Typelevel Summit is a community conference and we strive to make it an inclusive and fulfilling event for all participants. All attendees, speakers, and organizers must abide by the [Typelevel Code of Conduct](http://typelevel.org/conduct.html)

--- a/_events/2017-03-23-summit-nyc.md
+++ b/_events/2017-03-23-summit-nyc.md
@@ -72,3 +72,7 @@ For more information about the venue and accommodation, check out the [NE Scala 
 If you would like to talk to us about sponsorship options, please get in touch with us:
 
 <a class="btn large" href="mailto:info@typelevel.org">Become a sponsor</a>
+
+## Code of Conduct
+
+The Typelevel Summit is a community conference and we strive to make it an inclusive and fulfilling event for all participants. All attendees, speakers, and organizers must abide by the [Typelevel Code of Conduct](http://typelevel.org/conduct.html)

--- a/_events/2017-06-03-summit-copenhagen.md
+++ b/_events/2017-06-03-summit-copenhagen.md
@@ -62,3 +62,7 @@ Use code **typelevel** to receive <a href="https://secure.trifork.com/scaladays-
 If you would like to talk to us about sponsorship options, please get in touch with us:
 
 <a class="btn large" href="mailto:info@typelevel.org">Become a sponsor</a>
+
+## Code of Conduct
+
+The Typelevel Summit is a community conference and we strive to make it an inclusive and fulfilling event for all participants. All attendees, speakers, and organizers must abide by the [Typelevel Code of Conduct](http://typelevel.org/conduct.html)

--- a/_events/2017-06-03-summit-copenhagen.md
+++ b/_events/2017-06-03-summit-copenhagen.md
@@ -26,6 +26,8 @@ The Summits are open to all, not just current contributors to and users of the T
 Whilst many of the Typelevel projects use somewhat "advanced" Scala, they are a lot more approachable than many people think, and a major part of Typelevel's mission is to make the ideas they embody much more widely accessible.
 If you're interested in types and pure functional programming we'd love to see you here!
 
+This is a community conference and we strive to make it an inclusive and fulfilling event for all participants. All attendees, speakers, and organizers must abide by the [Typelevel Code of Conduct](http://typelevel.org/conduct.html).
+
 ## Call for Speakers
 
 The Summit will feature both 30 minute and 15 minute-long talks.
@@ -62,7 +64,3 @@ Use code **typelevel** to receive <a href="https://secure.trifork.com/scaladays-
 If you would like to talk to us about sponsorship options, please get in touch with us:
 
 <a class="btn large" href="mailto:info@typelevel.org">Become a sponsor</a>
-
-## Code of Conduct
-
-The Typelevel Summit is a community conference and we strive to make it an inclusive and fulfilling event for all participants. All attendees, speakers, and organizers must abide by the [Typelevel Code of Conduct](http://typelevel.org/conduct.html)


### PR DESCRIPTION
I feel better about encouraging people to apply for the CFP/attend the event when things like this are made explicit.

Addresses https://github.com/typelevel/typelevel.github.com/issues/139