### PR TITLE
make rss great again

### DIFF
--- a/_includes/license.html
+++ b/_includes/license.html
@@ -1,0 +1,4 @@
+<h2>Licensing</h2>
+<p>
+  Unless otherwise noted, all content is licensed under a <a href="https://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a>.
+</p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,6 +7,8 @@ layout: default
 
   {{ content }}
 
+{% include license.html %}
+ 
   <div class="post__author js-fade-in">
     {% assign author = site.data.authors[page.meta.author] %}
     {% if author %}

--- a/about.html
+++ b/about.html
@@ -45,10 +45,7 @@ title: About
     {{ conduct | markdownify }}
   </div>
 
-  <h2>Licensing</h2>
-  <p>
-    Unless otherwise noted, all content is licensed under a <a href="https://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a>.
-  </p>
+{% include license.html %}
 
   <h3>Images</h3>
   <p>

--- a/blog/feed.rss
+++ b/blog/feed.rss
@@ -14,7 +14,7 @@ layout: empty
         {% if post.meta.author %}
           <dc:creator>{{ post.meta.author | xml_escape }}</dc:creator>
         {% endif %}        
-        <description>{{ post.content | xml_escape }}</description>
+        <description><![CDATA[{{ post.content }}{% include license.html %}]]></description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ site.baseurl }}{{ post.url }}</link>
         <guid isPermaLink="true">{{ site.baseurl }}{{ post.url }}</guid>

--- a/blog/feed.rss
+++ b/blog/feed.rss
@@ -10,8 +10,8 @@ layout: empty
     {% for post in site.posts %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        {% if post.author.name %}
-          <dc:creator>{{ post.author.name | xml_escape }}</dc:creator>
+        {% if post.meta.author %}
+          <dc:creator>{{ post.meta.author | xml_escape }}</dc:creator>
         {% endif %}        
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>

--- a/blog/feed.rss
+++ b/blog/feed.rss
@@ -7,6 +7,7 @@ layout: empty
     <title>{{ site.name | xml_escape }}</title>
     <description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>    
     <link>{{ site.baseurl }}</link>
+    <copyright>CC BY 3.0</copyright>
     {% for post in site.posts %}
       <item>
         <title>{{ post.title | xml_escape }}</title>

--- a/blog/feed.rss
+++ b/blog/feed.rss
@@ -7,17 +7,13 @@ layout: empty
     <title>{{ site.name | xml_escape }}</title>
     <description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>    
     <link>{{ site.baseurl }}</link>
-    {% for post in site.posts limit:10 %}
+    {% for post in site.posts %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
         {% if post.author.name %}
           <dc:creator>{{ post.author.name | xml_escape }}</dc:creator>
         {% endif %}        
-        {% if post.excerpt %}
-          <description>{{ post.excerpt | xml_escape }}</description>
-        {% else %}
-          <description>{{ post.content | xml_escape }}</description>
-        {% endif %}
+        <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ site.baseurl }}{{ post.url }}</link>
         <guid isPermaLink="true">{{ site.baseurl }}{{ post.url }}</guid>


### PR DESCRIPTION
I am a user of rss feed aggregators and find the current rss feed not as
useful as it could be. You can checkout the current state by looking at
http://typelevel.org/blog/feed.rss on feedbucket.com. The list of blog posts is
limited to 10 entries and the descriptions are very terse.

The terseness, I think, is a bug with the `{% if post.excerpt %}` line.
At some point Jekyll decided to auto-generate excerpts if one is not
given in the YAML header. So I think this `if` statement is always true.

I greped the posts directory and found no use of the `excerpt` variable
so I made the decision to just remove the use of the variable in the
feed.rss file.

The end result is a useful rss feed. It can be previewed at
feedbucket.com using this link
https://gist.githubusercontent.com/jarrodwb/003ea9995134bde814e6d3545529e483/raw/bbc5d244c734f55fce77dc5b08fc8140be32abea/rss-fixes.rss.

The formatting is beautiful on feedbin.com. This is the aggregator I use.