### PR TITLE
Change Mouse github URL to repo under Typelevel

### DIFF
--- a/_data/incubator.yml
+++ b/_data/incubator.yml
@@ -21,7 +21,7 @@
   github: "https://github.com/kailuowang/mainecoon"
 - title: "Mouse"
   description: "Small companion library to cats providing enrichments to std lib classes to ease functional programming and/or ease source compatibility with scalaz"
-  github: "https://github.com/benhutchison/mouse"
+  github: "https://github.com/typelevel/mouse"
 - title: "OutWatch"
   description: "A functional and reactive UI framework for more predictable code"
   github: "https://github.com/OutWatch/outwatch"


### PR DESCRIPTION
Mouse was recently moved to Typelevel.
This change update the github URL on the site.