### PR TITLE
Add Product with Serializable blog post

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -309,3 +309,7 @@ annettebieniusa:
   full_name: "Annette Bieniusa"
   portrait: "/img/media/speakers/annettebieniusa.jpg"
   bio: "Annette is a lecturer and senior researcher at the Technische Universität Kaiserslautern. Her research interests include semantics of concurrent and distributed programming, with a focus on replication, synchronization, and how they are reflected on programming language level. Annette was involved in several national and international research projects, most recently the in the EU-Projects “SyncFree: Large-scale Computation without Synchronization” and “Lightkone: Lightweight computation for networks at the edge“."
+ceedubs:
+  full_name: "Cody Allen"
+  twitter: "FouriersTrick"
+  github: "ceedubs"

--- a/posts/2018-05-09-product-with-serializable.md
+++ b/posts/2018-05-09-product-with-serializable.md
@@ -15,7 +15,7 @@ tut:
 
 ---
 
-A somewhat common scala idiom is to make an `abstract` type extend `Product with Serializable`. There isn't an obvious reason to do this, and people have asked me a number of times why I've done this. While I don't think that `Product` or `Serializable` are particularly good abstractions, there's a reason that I extend them.
+A somewhat common Scala idiom is to make an `abstract` type extend `Product with Serializable`. There isn't an obvious reason to do this, and people have asked me a number of times why I've done this. While I don't think that `Product` or `Serializable` are particularly good abstractions, there's a reason that I extend them.
 
 Let's say that I'm writing a simple enum-like `Status` type:
 

--- a/posts/2018-05-09-product-with-serializable.md
+++ b/posts/2018-05-09-product-with-serializable.md
@@ -1,0 +1,65 @@
+---
+layout: post
+title: Product with Serializable
+
+meta:
+  nav: blog
+  author: ceedubs
+  pygments: true
+
+tut:
+  scala: 2.12.4
+  binaryScala: "2.12"
+  dependencies:
+    - org.scala-lang:scala-library:2.12.4
+
+---
+
+A somewhat common scala idiom is to make an `abstract` type extend `Product with Serializable`. There isn't an obvious reason to do this, and people have asked me a number of times why I've done this. While I don't think that `Product` or `Serializable` are particularly good abstractions, there's a reason that I extend them.
+
+Let's say that I'm writing a simple enum-like `Status` type:
+
+```tut:silent
+object EnumExample1 {
+  sealed abstract class Status
+  case object Pending extends Status
+  case object InProgress extends Status
+  case object Finished extends Status
+}
+```
+
+Now let's create a `Set` of statuses that represent incomplete items:
+
+```tut:silent
+import EnumExample1._
+```
+
+```tut:book
+val incomplete = Set(Pending, InProgress)
+```
+
+Here, I didn't give in explicit return type to `incomplete` and you may have noticed that the compiler inferred a somewhat bizarre one: `Set[Product with Serializable with Status]`. Why is that?
+
+The compiler generally tries to infer the most specific type possible. Usually this makes sense. If you write `val x = 3` you probably don't want it to infer `val x: Any = 3`. And in the example above, I didn't want the return type for `incomplete` to be inferred as `Any` or even `Set[Any]`. However, the compiler was a bit _too_ clever and realized that not only is every item in the set an instance of `Status`, they are also instances of `Product` and `Serializable` since every `case object` (and `case class`) automatically extends `Product` and `Serializable`. Therefore, when it calculates the least upper bound (LUB) of the types in the set, it comes up with `Product with Serializable with Status`.
+
+While there's nothing inherently wrong with the return type of `Product with Serializable with Status`, it is verbose, it wasn't what I intended, and in certain situations it might cause inference issues. Luckily there's a simple workaround to get the inferred type that I want:
+
+```tut:silent
+object EnumExample2 {
+  // note the `extends` addition here
+  sealed abstract class Status extends Product with Serializable
+  case object Pending extends Status
+  case object InProgress extends Status
+  case object Finished extends Status
+}
+```
+
+```tut:silent
+import EnumExample2._
+```
+
+```tut:book
+val incomplete = Set(Pending, InProgress)
+```
+
+Now since `Status` itself already includes `Product` and `Serializable`, `Status` is the LUB type of `Pending`, `InProgress`, and `Finished`.


### PR DESCRIPTION
This is a document that I've had sitting on my laptop for a while. I
figured that I might as well put it in a public place, and the typelevel
blog is the first place that came to mind.

I now see that Noel Welsh has published something similar [here](https://underscore.io/blog/posts/2015/06/04/more-on-sealed.html).
This goes into a bit more detail with type LUBs, which may be helpful to
someone?