### PR TITLE
Remove "experimental" from Cats description

### DIFF
--- a/_projects/cats.md
+++ b/_projects/cats.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Cats"
 category: "Functional Programming"
-description: "An experimental library intended to provide abstractions for functional programming in Scala, leveraging its unique features. Design goals are approachability, modularity, documentation and efficiency."
+description: "A library intended to provide abstractions for functional programming in Scala, leveraging its unique features. Design goals are approachability, modularity, documentation and efficiency."
 permalink: "https://typelevel.org/cats/"
 github: "https://github.com/typelevel/cats"
 


### PR DESCRIPTION
At this point Cats is pretty stable and is used widely in production and
across other libraries. I think that we can remove the "experimental"
tag.