### PR TITLE
Remove historical events from the home page

### DIFF
--- a/_events/2018-03-20-summit-boston.md
+++ b/_events/2018-03-20-summit-boston.md
@@ -10,8 +10,6 @@ description: "One day of recorded talks and one day of unconference, co-located 
 poster_hero: "/img/media/cambridge.jpg"
 poster_thumb: "/img/media/cambridge-thumb.jpg"
 
-featured: true
-
 sponsors_section: true
 
 sponsors:

--- a/_events/2018-05-18-summit-berlin.md
+++ b/_events/2018-05-18-summit-berlin.md
@@ -10,8 +10,6 @@ description: "One day of recorded talks after Scala Days."
 poster_hero: "/img/media/berlin.jpg"
 poster_thumb: "/img/media/berlin-thumb.jpg"
 
-featured: true
-
 sponsors_section: true
 
 sponsors:

--- a/index.html
+++ b/index.html
@@ -16,9 +16,10 @@ class: home
 <div class="section events js-fade-in">
   <h2>Upcoming Events</h2>
   <p>
-    For the third year, we are organizing the Typelevel Summits.
-    Join us in the US, Europe or both for our community-based events.
-  </p>
+    For the third year, we have organized successful Typelevel Summits in
+    Europe and North America. There are currently no upcoming events planned,
+    but please check back here for future announcements about our
+    community-based events.</p>
 
   {% for event in site.events %}
     {% if event.featured %}


### PR DESCRIPTION
These events are over, so they should no longer be featured on the home page.