### PR TITLE
Remove circe from Typelevel projects

### DIFF
--- a/_projects/circe.md
+++ b/_projects/circe.md
@@ -1,7 +1,0 @@
----
-layout: post
-title: "circe"
-category: "Principled JSON processing"
-description: "Yet another JSON library for Scala which integrates with cats, shapeless and Monocle."
-github: "https://github.com/travisbrown/circe"
----


### PR DESCRIPTION
I don't really see any value in having circe listed as a Typelevel project. The removal here doesn't change anything about the way circe is maintained, or anything at all, really, apart from the fact that "circe is a Typelevel project" will no longer be true.

r? @larsrh @milessabin @non 