### PR TITLE
Change NEScala link from Twitter post to https://nescala.io

### DIFF
--- a/_events/2019-04-01-summit-philadelphia.md
+++ b/_events/2019-04-01-summit-philadelphia.md
@@ -17,7 +17,7 @@ sponsors_section: true
 
 ## About the Summit
 
-The seventh Typelevel Summit will once again be co-located with the <a href="https://twitter.com/nescalas/status/1086306457556054016">Northeast Scala Symposium</a> in Philadelphia, with one day of recorded talks and one day of unconference.
+The seventh Typelevel Summit will once again be co-located with the <a href="https://nescala.io">Northeast Scala Symposium</a> in Philadelphia, with one day of recorded talks and one day of unconference.
 The schedule for this year is as follows:
 
 * April 1st: Typelevel Summit


### PR DESCRIPTION
I think it's better to point to the NEScala web site, now that it's up. The info on the site is more detailed than the info on the Twitter post.