### PR TITLE
Link to Scala CoC instead of Typelevel CoC from /about.html

### DIFF
--- a/about.html
+++ b/about.html
@@ -34,7 +34,7 @@ title: About
   <h2>Scala Code of Conduct</h2>
   <p>{% include code_of_conduct_header.html %}<br><br>
 
-  <a class="btn text center js-expand-coc" href="/conduct.html">Read full Code of Conduct</a></p>
+  <a class="btn text center js-expand-coc" href="/code_of_conduct.html">Read full Code of Conduct</a></p>
 
   <div class="content content-small centered coc" id="CoC">
     <!-- trick thanks to http://wolfslittlestore.be/2013/10/rendering-markdown-in-jekyll/ -->


### PR DESCRIPTION
@larsrh caught this on #257 and I overlooked it until after I'd hit merge.