### PR TITLE
Synchronize Scala Code of Conduct with upstream

### DIFF
--- a/_includes/code-of-conduct-header.html
+++ b/_includes/code-of-conduct-header.html
@@ -1,4 +1,5 @@
 We are committed to providing a friendly, safe and welcoming environment for
-all, regardless of level of experience, gender, gender identity and expression,
-sexual orientation, disability, personal appearance, body size, race, ethnicity,
-age, religion, nationality, or other such characteristics.
+all, regardless of age, body size, disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, sexual identity
+and orientation, or other such characteristics.

--- a/_includes/code-of-conduct.html
+++ b/_includes/code-of-conduct.html
@@ -6,19 +6,17 @@ As a member of the community, you agree to the following:
 
 **Encouraged:**
 
-- Be kind and courteous.
-- Respect differences of opinion and remember that every design or implementation choice carries a trade-off and numerous costs. There is seldom a single right answer.
-- Remember that everyone was new to Scala at some point. We want to encourage newcomers to join our community and learn the Scala language and ecosystem. Assume competence.
-- Show empathy towards other community members.
+- **Be kind and courteous.** We treat our fellow community members with the empathy, respect and dignity all humans deserve. Keep in mind that public communication is received by many people you don’t know, so before sending a message please ask yourself whether someone from a different context would misunderstand it.
+- **Respect differences of opinion** and remember that every design or implementation choice carries a trade-off and numerous costs. There is seldom a single right answer; we will find the best solutions by engaging in constructive discussion, with everybody bringing their unique viewpoint and experience to the table.
+- **Remember that everyone was new to Scala at some point.** We want to encourage newcomers to join our community and learn the Scala language and ecosystem. Always assume good intentions and a willingness to learn, just as you are willing to evolve your own opinion as you gain new insights.
 
 **Discouraged:**
 
 - Keep unstructured critique to a minimum. We encourage sharing ideas and perspectives, so please ensure that your feedback is constructive and relevant. If you have solid ideas you want to experiment with, make a fork and see how it works.
-- Avoid aggressive and micro-aggressive behavior, such as unconstructive criticism, providing correction
-s that do not improve the conversation (sometimes referred to as "well actually"s), repeatedly interrupting or talking over someone else, feigning surprise at someone’s lack of knowledge or awareness about a topic, or subtle prejudice (for example, comments like “That’s so easy my grandmother could do it.”). For more examples of this kind of behavior, [see the Recurse Center's user manual](https://www.recurse.com/manual#sec-environment).
-- We will exclude you from interaction if you insult, demean or harass anyone. The term “Harassment” includes “Unacceptable Behavior” described in the [Citizen Code of Conduct](http://citizencodeofconduct.org/). **In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.**
-- Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member's behavior, please [contact one of the moderators](#contact) immediately.
-- Likewise any spamming, trolling, flaming, baiting or other attention-stealing behaviour is not welcome.
+- Avoid aggressive and micro-aggressive behavior, such as unconstructive criticism, providing corrections that do not improve the conversation, repeatedly interrupting or talking over someone else, feigning surprise at someone’s lack of knowledge or awareness about a topic, or subtle prejudice (for example, comments like “That’s so easy my grandmother could do it.”). For more examples of this kind of behavior, [see the Recurse Center's user manual](https://www.recurse.com/manual#sec-environment).
+- We will exclude you from interaction if you insult, demean or harass anyone. See [examples of unacceptable behavior](#examples-of-unacceptable-behavior) below. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
+- Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member's behavior, please [contact the moderation team](#contact) immediately.
+- Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
 
 ### Moderation
 
@@ -26,7 +24,7 @@ These are the policies for upholding our community’s standards of conduct. If
 you feel that a thread needs moderation, please
 [contact the moderation team](#contact).
 
-- Remarks that violate the above code of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
+- Remarks that violate the above code of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful or aggressive manner.)
 - Moderators will warn users who make remarks inconsistent with the above code of conduct.
 - If the warning is unheeded, the user will be “kicked,” i.e., kicked out of the communication channel to cool off.
 - If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.
@@ -52,7 +50,7 @@ eager to assume good intent and forgive.
 
 ### Domain
 
-The enforcement policies listed above apply to all Typelevel channels:
+The enforcement policies listed above apply to all official Typelevel channels:
 mailing lists, GitHub repositories and Gitter channels under the `typelevel`
 organization, Discourse, and Typelevel venues and hackathons. For other
 projects adopting the Scala Code of Conduct, please contact the maintainers of
@@ -68,12 +66,29 @@ listed above,
 * contact one of the moderators active on that channel if you can identify
   them, or
 * send an e-mail to one of the following general moderators if you want to
-choose who you are talking to:
+  choose who you are talking to:
   * [Ross A. Baker](mailto:ross@rossabaker.com)
   * [Christopher Davenport](mailto:chris@chrisdavenport.tech)
   * [Erik Osheim](mailto:d_m@plastic-idolatry.com)
   * [Miles Sabin](mailto:miles@milessabin.com)
   * [Kailuo Wang](mailto:kailuo.wang@gmail.com)
+
+### Examples of unacceptable behavior
+
+Behavior that will lead to exclusion includes the following points, inspired by the definition of
+“Unacceptable Behavior” in the [Citizen Code of Conduct](http://citizencodeofconduct.org/):
+
+* Violence, threats of violence or violent language directed against another person.
+* Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+* Posting or displaying sexually explicit or violent material.
+* Posting or threatening to post other people’s personally identifying information ("doxing").
+* Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+* Inappropriate photography or recording.
+* Inappropriate physical contact. You should have someone’s consent before touching them.
+* Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
+* Deliberate intimidation, stalking or following (online or in person).
+* Advocating for, or encouraging, any of the above behavior.
+* Sustained disruption of community events, including talks and presentations.
 
 ### Credits
 
@@ -88,3 +103,8 @@ Adapted from and/or inspired by multiple successful Codes of Conduct, including:
 * [The Contributor Covenant v1.4.0](http://contributor-covenant.org/version/1/4/)
 * [The Recurse Center's User Manual](https://www.recurse.com/manual#sec-environment)
 * [The 18F Code of Conduct](https://18f.gsa.gov/code-of-conduct/)
+* [Citizen Code of Conduct](http://citizencodeofconduct.org/)
+
+### License
+
+This Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike license](https://creativecommons.org/licenses/by-sa/3.0/).


### PR DESCRIPTION
I can dig up relevant ticket links if demanded, but this gets us back to [0f8d4703](https://github.com/scala/scala-lang/blob/0f8d470312b42134fc993592c704fb0c32253dd4/conduct.md), with our deltas for venues and moderators.

Thanks to @SethTisue for the gentle reminders, and all who improved things upstream.