### PR TITLE
renamed joinAndEmbedNever to joinWithNever in 2020-10-30 blog post

### DIFF
--- a/_posts/2020-10-30-concurrency-in-ce3.md
+++ b/_posts/2020-10-30-concurrency-in-ce3.md
@@ -194,11 +194,11 @@ object ExampleOne extends IOApp.Simple {
     for {
       fa <- (repeat("A") *> repeat("B")).as("foo!").start
       fb <- (repeat("C") *> repeat("D")).as("bar!").start
-      // joinAndEmbedNever is a variant of join that asserts
+      // joinWithNever is a variant of join that asserts
       // the fiber has an outcome of Succeeded and returns the
       // associated value.
-      ra <- fa.joinAndEmbedNever
-      rb <- fb.joinAndEmbedNever
+      ra <- fa.joinWithNever
+      rb <- fb.joinWithNever
       _ <- IO.println(s"\ndone: a says: $ra, b says: $rb")
     } yield ()
 }


### PR DESCRIPTION
renamed joinAndEmbedNever to joinWithNever as per https://github.com/typelevel/cats-effect/issues/1500

did not check the correctness of any other examples