### PR TITLE
Push to Typelevel cachix instance

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,30 @@
+name: cachix
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.2
+
+      - name: "Install Nix️"
+        uses: cachix/install-nix-action@v15
+
+      - name: "Install Cachix️"
+        uses: cachix/cachix-action@v10
+        with:
+          name: typelevel
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: "Build dev shells"
+        run: for shell in library application; do nix develop .#${shell} -c true; done

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -26,5 +26,5 @@ jobs:
           name: typelevel
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: "Build dev shells"
-        run: for shell in library application; do nix develop .#${shell} -c true; done
+      - name: "Build dev shell"
+        run: nix develop -c true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
       - name: "Install Nix️"
         uses: cachix/install-nix-action@v16
 
-
-      - name: "Why am I dirty?"
-        run: git status
+      - name: "Install Cachix️"
+        uses: cachix/cachix-action@v10
+        with:
+          name: typelevel
 
       - name: "Nix Flake Check"
         run: nix -L flake check

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The generated site will end up in the `_site` directory.
 
 #### Nix
 
-A fully configured Jekyll is available as a Nix app.  Assumes that you have [installed Nix](https://nixos.org/download.html) and [enabled flakes](https://nixos.wiki/wiki/Flakes#Installing_flakes):
+A fully configured Jekyll is available as a Nix app.  Assumes that you have [installed Nix](https://nixos.org/download.html) and [enabled flakes](https://nixos.wiki/wiki/Flakes#Installing_flakes).  You may optionally use the [Typelevel Cachix](https://app.cachix.org/cache/typelevel#pull).
 
 ```console
 $ nix run github:typelevel/typelevel.github.com#jekyll build


### PR DESCRIPTION
I created a [Typelevel cachix](https://app.cachix.org/cache/typelevel#pull) instance.  This will cache the dev shell for MacOS and Linux, and use the cachix to potentially speed up the CI.