### PR TITLE
Point to the official steering committee listing

### DIFF
--- a/steering.md
+++ b/steering.md
@@ -3,15 +3,10 @@ layout: page
 title: Typelevel Steering Committee
 ---
 
-The Typelevel Steering Committee is the group of volunteers that governs Typelevel:
+The Typelevel Steering Committee is the group of volunteers that
+governs Typelevel.  The membership is kept in [the Typelevel
+Governance repository][steering-committee] and described in the
+[Typelevel Charter][charter].
 
-* Ross A. Baker
-* Oscar Boykin
-* Christopher Davenport
-* Luka Jacobowitz
-* Alexandru Nedelcu
-* Rob Norris
-* Michael Pilquist
-* Miles Sabin
-* Daniel Spiewak
-* Kailuo Wang
+[steering-committee]: https://github.com/typelevel/governance/blob/main/STEERING-COMMITTEE.md
+[charter]: https://github.com/typelevel/governance/blob/main/CHARTER.md


### PR DESCRIPTION
It would be better to synchronize this list from governance (#326), but this indirection keeps it accurate in the meantime.