### PR TITLE
Restore "core" projects to front page

### DIFF
--- a/_includes/_section-projects.html
+++ b/_includes/_section-projects.html
@@ -5,7 +5,8 @@
       <p>{{site.data.description.projectsDescription}}</p>
     </div>
     <div class="projects-list">
-      {% for project in site.projects limit:3 %}
+      {% assign projects = site.projects | where:'core', true %}
+      {% for project in projects limit:3 %}
       <a href="{{ project.github }}" class="project-item" data-aos="fade-down">
         <div class="project-item-content">
           <div>


### PR DESCRIPTION
We can quibble about which these are, but this matches the status quo.

See #347.