### PR TITLE
Fix README typo and add 2022-07 new members post

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you just want to add a blog post or fix a typo in the content, here's how to 
 
 ### Creating a blog post
 
-1. Create a new file in the `posts` directory or copy an existing post. Its name should have the format `YYYY-MM-DD-short_title.md`.
+1. Create a new file in the [`_posts`](./_posts/) directory or copy an existing post. Its name should have the format `YYYY-MM-DD-short_title.md`.
 2. Set the `title` (short title of the post, appears as the HTML `<title>`) and `author` (your GitHub user name) in the front matter. MathJax is available via `mathjax: true` inside the front matter.
 3. If this is your first blog post, please indicate if you want your name and a profile picture to appear on the post. If not, you can remove the `author` field from the front matter. Add your details in `_data/authors.yml`.
 4. Write your content using Markdown. For code highlighting, use the usual GitHub syntax:

--- a/_posts/2022-07-25-welcoming-new-steering-committee-members.md
+++ b/_posts/2022-07-25-welcoming-new-steering-committee-members.md
@@ -1,0 +1,64 @@
+---
+layout: post
+title: Welcoming New Steering Committee Members
+
+meta:
+  nav: blog
+  author: typelevel
+---
+
+Since our [last post][last-post], the [Typelevel Steering Committee][committee] has happily welcomed six new members to our group: Zach McCoy, Sam Pillsworth, Jasna Rodulfa-Blemberg, Andrew Valencik, Vasil Vasilev, and Mark Waks (aka Justin du Coeur). In their own words:
+
+[Zach McCoy][zach] (he/him)
+
+I've been programming in Scala professionally for 10 years. I currently work at [Jack Henry][jack-henry] where I get to work in Scala and deal with observability in systems.  I'm based in Iowa where I work remotely.  I can usually be found reading or playing Magic: The Gathering.  
+
+[Sam Pillsworth][sam] (she/her)
+
+I’ve been writing code in industry for about 7 years, and the programming before that doesn’t count because it was in Fortran. Currently I'm a senior data developer writing Scala to power search in the [Shopify][shopify] [Help Center][shopify-helpcenter]. I’m based out of Toronto, Ontario, Canada. In my free time I read a lot of books, play with my dog Janeway, and futz with my emacs config.
+
+[Jasna Rodulfa-Blemberg][jasna] (she/they)
+
+I've been programming in Scala for the past 5 years, and more broadly in the JVM for most of my 9-year career. I currently work for [Etsy][etsy], where I help scale and maintain their search platform using Scala. I work remotely from the Washington, DC, USA area with my partner and the wild rabbits in my yard. 
+
+I love cooking, gaming, reading, writing, and staying fit. More recently, I've begun reviving my Japanese language skills from college.
+
+[Andrew Valencik][andrew] (he/him)
+
+I've been writing Scala for 6ish years, on and off. Currently I manage a data science team and a developer team at [Shopify][shopify] working on search systems in the support area. I live in Ottawa, Ontario, Canada.
+
+I like cooking when I have all day to do it, being outside, and rotating through hobbies.
+
+[Vasil Vasilev][vasil] (he/him)
+
+I've been doing Scala for about 5 years now and for about 3 years in the open-source community. I'm a software developer at [JetBrains][jetbrains], working on the Scala Plugin team out of Munich, Germany.
+
+I like to split my free time between cycling, gaming and reading, as well as Scala open-source contributions, especially Cats Effect.
+
+[Mark Waks, aka Justin du Coeur][justin] (he/him)
+
+I've been programming for about 40 years in a wide variety of languages, the past 10 full-time in Scala. My current dayjob is at [Troops][troops] (now part of Slack/Salesforce), working remotely from Somerville, MA; in my spare time, I run [Querki][querki], a sort of wiki/database hybrid written entirely in Scala.
+
+I'm a pretty generalized geek, active in SCA, LARP, SF/F fandom, board games, comics, etc. I'm in charge of the Boston Scala Meetup, and on the board of the NE Scala conference (both currently dormant due to covid).
+
+--------
+
+These new members are excited to continue Typelevel's efforts to foster an inclusive, welcoming, and safe environment around functional programming in Scala. You can find the members throughout the [Typelevel GitHub space][github] and on our [Discord server][discord] with the `@steering` role.
+
+[andrew]: https://github.com/valencik
+[committee]: https://github.com/typelevel/governance/blob/main/STEERING-COMMITTEE.md
+[discord]: https://sca.la/typeleveldiscord
+[etsy]: https://etsy.com
+[github]: https://github.com/typelevel
+[jack-henry]: https://www.jackhenry.com/pages/default.aspx
+[jasna]: https://github.com/JasnaMRB
+[jetbrains]: https://jetbrains.co
+[justin]: https://github.com/jducoeur
+[last-post]: https://typelevel.org/blog/2022/04/01/call-for-steering-committee-members.html
+[querki]: https://querki.net/
+[sam]: https://github.com/samspills
+[shopify]: https://www.shopify.com
+[shopify-helpcenter]: https://help.shopify.com/en
+[troops]: https://www.troops.ai/
+[vasil]: https://github.com/vasilmkd
+[zach]: https://github.com/zmccoy


### PR DESCRIPTION
Slightly changed closing paragraph and and opening paragraph from steering committee's shared draft -- added a reference to the previous post in the opening paragraph.

I'll be out of town this upcoming week, so if any changes need to be pushed, @rossabaker or others are welcome to do so! I should still have access to comment on this PR and press buttons via my phone, though. I set the date to this coming Monday for now -- open to that change as well.

FYI: I can't get the site to build via the first recommended method in the README, so I haven't been able to preview these changes other than via my Markdown viewer. Unfortunately I don't have time to look too deep into it yet...

gist in case it may be worth a separate bug report, or otherwise I may have missed a build step: https://gist.github.com/JasnaMRB/8600a578865596cdb56ed25bf2eb4d8b