### PR TITLE
Copy updates, add steering committee cta to about page

### DIFF
--- a/_data/about.yml
+++ b/_data/about.yml
@@ -1,5 +1,5 @@
 - title: "Open source"
-  description: "Independent, free/libre and open-source software"
+  description: "Independent, free/libre, and open-source software"
   icon: /img/assets/icon-about-open-source.svg
 
 - title: "Functional"
@@ -15,7 +15,7 @@
   icon: /img/assets/icon-about-resources.svg
 
 - title: "Friendly"
-  description: "An inclusive, welcoming and safe environment"
+  description: "An inclusive, welcoming, and safe environment"
   icon: /img/assets/icon-about-friendly.svg
 
 - title: "Modular"

--- a/_data/cta.yml
+++ b/_data/cta.yml
@@ -11,4 +11,4 @@ conductTitle: Scala Code of Conduct
 conductDescription: We are committed to providing a friendly, safe and welcoming environment for all, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, sexual identity and orientation, or other such characteristics.
 
 steeringTitle: Steering Committee
-steeringDescription: The Typelevel Steering Committee is a group of volunteers that governs Typelevel.
+steeringDescription: The Typelevel Steering Committee is a group of volunteers that govern Typelevel.

--- a/_data/cta.yml
+++ b/_data/cta.yml
@@ -9,3 +9,6 @@ blogDescription:  If you want to share something about a library or Scala topics
 
 conductTitle: Scala Code of Conduct
 conductDescription: We are committed to providing a friendly, safe and welcoming environment for all, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, sexual identity and orientation, or other such characteristics.
+
+steeringTitle: Steering Committee
+steeringDescription: The Typelevel Steering Committee is a group of volunteers that governs Typelevel.

--- a/_data/description.yml
+++ b/_data/description.yml
@@ -1,11 +1,11 @@
 aboutTitle: About
-aboutDescription: Learn more about the organization. Here you can see the main goals we are pursuing.
+aboutDescription: Learn more about the organization, including our main goals, code of conduct, and governance.
 
 projectsTitle: Projects
 projectsDescription: Our projects cover a wide range of domains, from general functional programming to tooling.
 
 blogTitle: Latest blog posts
-blogDescription: We show how to use our libraries in your code, provide examples, collect learning resources and explore implementation details.
+blogDescription: In addition to org-level announcements, here we show you how to use our libraries in your code, provide examples, collect learning resources, and explore implementation details.
 
 eventsTitle: Events
 

--- a/_data/nav-scala.yml
+++ b/_data/nav-scala.yml
@@ -3,3 +3,6 @@
 
 - title: License
   url: /license
+
+- title: Steering Committee
+  url: /steering-committee

--- a/_includes/_cta-steering.html
+++ b/_includes/_cta-steering.html
@@ -1,0 +1,15 @@
+<section id="section-blog" class="section-large">
+    <div class="container">
+        <div class="section-header">
+            <h2><span>{{site.data.cta.steeringTitle}}</span></h2>
+            <p>{{site.data.cta.steeringDescription}}</p>
+            {% for item in site.data.nav-scala %}
+            {% if item.title == "Steering Committee" %}
+            <p><br />
+            <a class="button button-primary" href="{{item.url | relative_url }}">About the Committee</a>
+            </p>
+            {% endif %}
+            {% endfor %}
+        </div>
+    </div>
+</section>

--- a/_includes/_section-about.html
+++ b/_includes/_section-about.html
@@ -4,17 +4,8 @@
       <h2><span>{{site.data.description.aboutTitle}}</span></h2>
       <p>{{{site.data.description.aboutDescription}}</p>
     </div>
-    <div class="about-list">
-      {% for item in site.data.about %}
-      <div class="about-item" data-aos="fade-down">
-          <img src="{{ site.baseurl }}{{ item.icon  }}" title="{{ item.title }}" />
-          <h3>{{item.title}}</h3>
-          <p>{{item.description}}</p>
-      </div>
-      {% endfor %}
-    </div>
     <div class="section-cta">
-        <a class="button button-primary" href="{{ site.baseurl }}/about/">See about</a>
+        <a class="button button-primary" href="{{ site.baseurl }}/about/">About Typelevel</a>
     </div>
   </div>
 </section>

--- a/about/index.html
+++ b/about/index.html
@@ -33,3 +33,5 @@ title: About
   </div>
 </div>
 {% include _cta-conduct.html %}
+<br /><br /><br />
+{% include _cta-steering.html %}

--- a/steering-committee.md
+++ b/steering-committee.md
@@ -1,12 +1,14 @@
 ---
-layout: page
-title: Typelevel Steering Committee
+layout: coc
+title: "Typelevel Steering Committee"
+permalink: /steering-committee.html
 ---
 
-The Typelevel Steering Committee is the group of volunteers that
+The Typelevel Steering Committee is a group of volunteers that
 governs Typelevel.  The membership is kept in [the Typelevel
 Governance repository][steering-committee] and described in the
 [Typelevel Charter][charter].
 
 [steering-committee]: https://github.com/typelevel/governance/blob/main/STEERING-COMMITTEE.md
 [charter]: https://github.com/typelevel/governance/blob/main/CHARTER.md
+

--- a/steering-committee.md
+++ b/steering-committee.md
@@ -5,7 +5,7 @@ permalink: /steering-committee.html
 ---
 
 The Typelevel Steering Committee is a group of volunteers that
-governs Typelevel.  The membership is kept in [the Typelevel
+govern Typelevel.  The membership is kept in [the Typelevel
 Governance repository][steering-committee] and described in the
 [Typelevel Charter][charter].
 


### PR DESCRIPTION
I realized we don't have any official link to steering committee information, other than our more date-dependent blog posts. Here's my attempt at resolving that.

### Home page

Modules from "About" page are removed. I think they take up a lot of space, and one could click on the About link to see them all. I also referenced the Code of Conduct and Steering Committee.

<img width="1394" alt="image" src="https://user-images.githubusercontent.com/568975/188330686-adae4c0a-8960-4662-85c1-1c7667d54d4a.png">


### About page

I added a simple white CTA for Steering Committee below the red CTA for Code of Conduct. It's very simply done, reusing some other CSS classes since I'm not a frontend expert... There is no other place in the current layout that has two CTAs next to each other, so I had to figure something out.

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/568975/188330740-5b431e69-8b7c-4ade-ad02-5e70ee169a1e.png">


### Steering committee page

add /steering-committee
<img width="1363" alt="image" src="https://user-images.githubusercontent.com/568975/188330652-f8749d6d-c6fb-4f8b-a9cf-1b9bcd183b6a.png">

### Blog description

I added a clause about org-level announcements, since we do that here in addition to technical posts.

<img width="1315" alt="image" src="https://user-images.githubusercontent.com/568975/188330795-7b9e86a6-615b-4ad3-9b29-12b7a00d6777.png">

