### PR TITLE
Revert "Update site baseUrl to fix RSS feed permalinks"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ permalink: pretty
 
 # Serving, url
 # ---------------------------------------------------------------
-baseurl: "https://typelevel.org"
+baseurl: "/typelevel.github.com"
 url: ""
 
 # Conversion


### PR DESCRIPTION
Reverts typelevel/typelevel.github.com#400

Breaks the site. Let's roll this back while we fix.