### PR TITLE
Bring back mathjax

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -15,5 +15,17 @@
   <link rel="stylesheet" href="{{ '/css/main.css' | relative_url }}">
 
   <link rel="alternate" type="application/rss+xml" title="Blog articles" href="{% link blog/feed.rss %}" />
-  
+
+  {% if page.meta.mathjax %}
+  <script>
+    window.MathJax = {
+      tex: {
+        inlineMath: [['$', '$'], ['\\(', '\\)']]
+      }
+    };
+  </script>
+  <script type="text/javascript" id="MathJax-script" async
+    src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
+  </script>
+  {% endif %}
 </head>


### PR DESCRIPTION
We used to do this as in 736cd9228716dc37aeff4e3bb535041e0970f0f8, but that script 404s and the config doesn't work anymore.  This is the same idea.  

Fixes #391.