### PR TITLE
Add a social pointer to Mastodon

### DIFF
--- a/_data/nav-social.yml
+++ b/_data/nav-social.yml
@@ -6,6 +6,10 @@
   url: https://twitter.com/typelevel
   icon: "fab fa-twitter"
 
+- title: Mastodon
+  url: https://fosstodon.org/@typelevel
+  icon: "fab fa-mastodon"
+
 - title: Discord
   url: https://discord.gg/XF3CXcMzqD
   icon: "fab fa-discord"

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -23,6 +23,10 @@ navSocial:
     url: https://twitter.com/typelevel
     icon: "fab fa-twitter"
 
+  - title: Mastodon
+    url: https://fosstodon.org/@typelevel
+    icon: "fab fa-mastodon"
+
   - title: Discord
     url: https://discord.gg/XF3CXcMzqD
     icon: "fab fa-discord"

--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -26,12 +26,11 @@
                 
                 {% for item in site.data.nav.navSocial %}
                 <li>
-                    <a href="{{ item.url | relative_url }}" target="_blank">
+                    <a rel="me" href="{{ item.url | relative_url }}" target="_blank">
                     <i class="{{ item.icon }}"></i>
                 </a>
                 </li>
                 {% endfor %}
-                <li><a rel="me" href="https://fosstodon.org/@typelevel" target="_blank"><i class="fab fa-mastodon"></i></a></li>
             </ul>
         </div>
     </div>

--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -31,6 +31,7 @@
                 </a>
                 </li>
                 {% endfor %}
+                <li><a rel="me" href="https://fosstodon.org/@typelevel" target="_blank"><i class="fab fa-mastodon"></i></a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
Specifically, our new official home at Fosstodon. This also serves as a verification link for Fosstodon, and the `rel="me"` is required, which is why it's being handled out-of-band from the other links; if we're comfortable always using `rel="me"` for social links, we could unify this.  (Opinions welcome.)

Fixes #403.