### PR TITLE
indent author metadata

### DIFF
--- a/collections/_posts/2022-11-10-fabric.md
+++ b/collections/_posts/2022-11-10-fabric.md
@@ -4,8 +4,8 @@ title: "Fabric: A New JSON Library"
 category: governance
 
 meta:
-nav: blog
-author: matthicks
+  nav: blog
+  author: matthicks
 ---
 
 I know what you're thinking! "A new JSON library? Why? Don't we have plenty of those?" Well, the short answer is a


### PR DESCRIPTION
Currently the blog isn't showing the author! I didn't realize initially but I think the indenting is necessary

<details><summary>current screenshot</summary>

![image](https://user-images.githubusercontent.com/4977741/201955883-973ff253-5675-4d95-b88f-b6d911445a8e.png)
</details>

This should fix things! 
cc @darkfrog26 