### PR TITLE
Add fs2-data to projects page

### DIFF
--- a/collections/_projects/fs2-data.md
+++ b/collections/_projects/fs2-data.md
@@ -1,0 +1,7 @@
+---
+title: "fs2-data"
+category: "Stream Processing"
+description: "Parse and transform data (CBOR, CSV, JSON, XML) in a streaming manner"
+github: "https://github.com/gnieh/fs2-data"
+affiliate: true
+---


### PR DESCRIPTION
Add fs2-data to the projects page.

Preview of the generated card:

<img width="362" alt="Screen Shot 2023-01-03 at 10 16 00 AM" src="https://user-images.githubusercontent.com/5440389/210386048-cb30e8dc-851d-4327-a910-3586b40f2b62.png">

@satabin Are you ok with this description?

Part of https://github.com/typelevel/governance/issues/69