### PR TITLE
Add filter tabs to Projects page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
+*.sw?
 .idea
 /vendor/bundle
 css/main.css
@@ -9,3 +10,4 @@ target
 .jekyll-cache/
 .metals
 .DS_Store
+.direnv/

--- a/_data/filter-projects.yml
+++ b/_data/filter-projects.yml
@@ -1,0 +1,9 @@
+- title: All Projects
+  url: /projects/
+  category: allProjects
+- title: Member
+  url: /projects/member/
+  category: member
+- title: Affiliate
+  url: /projects/affiliate/
+  category: affiliate

--- a/_data/filter-projects.yml
+++ b/_data/filter-projects.yml
@@ -1,9 +1,9 @@
 - title: All Projects
   url: /projects/
   category: allProjects
-- title: Member
-  url: /projects/member/
-  category: member
+- title: Organization
+  url: /projects/organization/
+  category: organization
 - title: Affiliate
   url: /projects/affiliate/
   category: affiliate

--- a/_includes/_project_membership.html
+++ b/_includes/_project_membership.html
@@ -1,0 +1,7 @@
+<div class="project-membership">
+  {% if project.affiliate %}
+  <img src="https://img.shields.io/badge/typelevel-affiliate%20project-FFB4B5.svg" alt="Typelevel Affiliate Project" />
+  {% else %}
+  <img src="https://img.shields.io/badge/typelevel-organization%20project-FF6169.svg" alt="Typelevel Organization Project" />
+  {% endif %}
+</div>

--- a/_includes/_tab-projects.html
+++ b/_includes/_tab-projects.html
@@ -1,0 +1,5 @@
+<ul class="tab">
+    {% for tabItem in site.data.filter-projects %}
+    <li><a href="{{ site.baseurl }}{{tabItem.url}}" {% if tabItem.url == page.url %} class="active" {% endif %}>{{tabItem.title}}</a></li>
+    {% endfor %}
+</ul>

--- a/projects/affiliate.html
+++ b/projects/affiliate.html
@@ -1,7 +1,9 @@
 ---
 layout: page
 title: Projects
+permalink: /projects/affiliate/
 ---
+
 <div id="section-page">
   <div class="container">
     <div class="masthead-page">
@@ -9,8 +11,10 @@ title: Projects
       <p>{{site.data.description.projectsDescription}}</p>
       {% include _tab-projects.html %}
     </div>
+
     <div class="projects-list">
       {% for project in site.projects %}
+      {% if project.affiliate %}
       <a href="{{ project.github }}" class="project-item">
         <div class="project-item-content">
           <div>
@@ -32,6 +36,7 @@ title: Projects
           {% endif %}
         </div>
       </a>
+      {% endif %}
       {% endfor %}
     </div>
   </div>

--- a/projects/affiliate.html
+++ b/projects/affiliate.html
@@ -32,7 +32,7 @@ permalink: /projects/affiliate/
           {% if project.affiliate %}
           <img src="https://img.shields.io/badge/typelevel-affiliate-FFB4B5" alt="Typelevel affiliate" />
           {% else %}
-          <img src="https://img.shields.io/badge/typelevel-member-FF6169" alt="Typelevel member" />
+          <img src="https://img.shields.io/badge/typelevel-organization-FF6169" alt="Typelevel organization" />
           {% endif %}
         </div>
       </a>

--- a/projects/affiliate.html
+++ b/projects/affiliate.html
@@ -28,9 +28,7 @@ permalink: /projects/affiliate/
           <p>{{ project.category }}</p>
         </div>
         {% endif %}
-        <div class="project-membership">
-          <img src="https://img.shields.io/badge/typelevel-affiliate-FFB4B5" alt="Typelevel affiliate" />
-        </div>
+        {% include _project_membership.html %}
       </a>
       {% endif %}
       {% endfor %}

--- a/projects/affiliate.html
+++ b/projects/affiliate.html
@@ -29,11 +29,7 @@ permalink: /projects/affiliate/
         </div>
         {% endif %}
         <div class="project-membership">
-          {% if project.affiliate %}
           <img src="https://img.shields.io/badge/typelevel-affiliate-FFB4B5" alt="Typelevel affiliate" />
-          {% else %}
-          <img src="https://img.shields.io/badge/typelevel-organization-FF6169" alt="Typelevel organization" />
-          {% endif %}
         </div>
       </a>
       {% endif %}

--- a/projects/index.html
+++ b/projects/index.html
@@ -24,13 +24,7 @@ title: Projects
           <p>{{ project.category }}</p>
         </div>
         {% endif %}
-        <div class="project-membership">
-          {% if project.affiliate %}
-          <img src="https://img.shields.io/badge/typelevel-affiliate-FFB4B5" alt="Typelevel affiliate" />
-          {% else %}
-          <img src="https://img.shields.io/badge/typelevel-organization-FF6169" alt="Typelevel organization" />
-          {% endif %}
-        </div>
+        {% include _project_membership.html %}
       </a>
       {% endfor %}
     </div>

--- a/projects/index.html
+++ b/projects/index.html
@@ -28,7 +28,7 @@ title: Projects
           {% if project.affiliate %}
           <img src="https://img.shields.io/badge/typelevel-affiliate-FFB4B5" alt="Typelevel affiliate" />
           {% else %}
-          <img src="https://img.shields.io/badge/typelevel-member-FF6169" alt="Typelevel member" />
+          <img src="https://img.shields.io/badge/typelevel-organization-FF6169" alt="Typelevel organization" />
           {% endif %}
         </div>
       </a>

--- a/projects/member.html
+++ b/projects/member.html
@@ -1,7 +1,9 @@
 ---
 layout: page
 title: Projects
+permalink: /projects/member/
 ---
+
 <div id="section-page">
   <div class="container">
     <div class="masthead-page">
@@ -9,8 +11,10 @@ title: Projects
       <p>{{site.data.description.projectsDescription}}</p>
       {% include _tab-projects.html %}
     </div>
+
     <div class="projects-list">
       {% for project in site.projects %}
+      {% if project.affiliate != true %}
       <a href="{{ project.github }}" class="project-item">
         <div class="project-item-content">
           <div>
@@ -32,6 +36,7 @@ title: Projects
           {% endif %}
         </div>
       </a>
+      {% endif %}
       {% endfor %}
     </div>
   </div>

--- a/projects/organization.html
+++ b/projects/organization.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Projects
-permalink: /projects/member/
+permalink: /projects/organization/
 ---
 
 <div id="section-page">

--- a/projects/organization.html
+++ b/projects/organization.html
@@ -32,7 +32,7 @@ permalink: /projects/organization/
           {% if project.affiliate %}
           <img src="https://img.shields.io/badge/typelevel-affiliate-FFB4B5" alt="Typelevel affiliate" />
           {% else %}
-          <img src="https://img.shields.io/badge/typelevel-member-FF6169" alt="Typelevel member" />
+          <img src="https://img.shields.io/badge/typelevel-organization-FF6169" alt="Typelevel organization" />
           {% endif %}
         </div>
       </a>

--- a/projects/organization.html
+++ b/projects/organization.html
@@ -28,9 +28,7 @@ permalink: /projects/organization/
           <p>{{ project.category }}</p>
         </div>
         {% endif %}
-        <div class="project-membership">
-          <img src="https://img.shields.io/badge/typelevel-organization-FF6169" alt="Typelevel organization" />
-        </div>
+        {% include _project_membership.html %}
       </a>
       {% endif %}
       {% endfor %}

--- a/projects/organization.html
+++ b/projects/organization.html
@@ -29,11 +29,7 @@ permalink: /projects/organization/
         </div>
         {% endif %}
         <div class="project-membership">
-          {% if project.affiliate %}
-          <img src="https://img.shields.io/badge/typelevel-affiliate-FFB4B5" alt="Typelevel affiliate" />
-          {% else %}
           <img src="https://img.shields.io/badge/typelevel-organization-FF6169" alt="Typelevel organization" />
-          {% endif %}
         </div>
       </a>
       {% endif %}


### PR DESCRIPTION
Add `/projects/organization` and `/projects/affiliate` pages along with tab selectors.

All Projects:
<img width="1222" alt="allProjects" src="https://user-images.githubusercontent.com/5440389/210579093-1c306283-40e3-4384-afc7-6c239480e51c.png">

Organization Projects:
<img width="1293" alt="organizationProjects" src="https://user-images.githubusercontent.com/5440389/210585082-1bbe8e74-40dc-4f2e-8c21-93a51c0d6885.png">


Afilliate Projects:
<img width="1222" alt="affiliateProjects" src="https://user-images.githubusercontent.com/5440389/210579082-b758acfa-7a30-454a-a818-5170ea42b30d.png">