### PR TITLE
Remove placeholder images from blog posts

### DIFF
--- a/_includes/_section-blog.html
+++ b/_includes/_section-blog.html
@@ -10,8 +10,6 @@
         <div class="blog-item-content">
           {% if post.image %}
           <img src="{{ site.baseurl }}{{ post.image }}" alt="">
-          {% else %}
-          <img src="{{ site.baseurl }}/img/blog/typelevel-placeholder.png" alt="">
           {% endif %}
           <div>
               <h3>{{ post.title }}</h3>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,8 +17,6 @@
         <p class="blog-detail-tag">{{ page.category }}</p>
         {% if page.image %} 
         <img src="{{ site.baseurl }}{{ page.image }}" alt="">
-        {% else %}
-        <img src="{{ site.baseurl }}/img/blog/typelevel-placeholder.png" alt="">
         {% endif %}
       </div>
       <div class="blog-detail-content">

--- a/blog/governance.html
+++ b/blog/governance.html
@@ -21,8 +21,6 @@ permalink: /blog/governance/
         <div class="blog-item-content">
           {% if post.image %}
             <img src="{{ site.baseurl }}{{ post.image }}" alt="">
-            {% else %}
-            <img src="{{ site.baseurl }}/img/blog/typelevel-placeholder.png" alt="">
             {% endif %}
 
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -19,8 +19,6 @@ title: Blog
         <div class="blog-item-content">
           {% if post.image %}
           <img src="{{ site.baseurl }}{{ post.image }}" alt="">
-          {% else %}
-          <img src="{{ site.baseurl }}/img/blog/typelevel-placeholder.png" alt="">
           {% endif %}
           <div>
               <h3>{{ post.title }}</h3>

--- a/blog/social.html
+++ b/blog/social.html
@@ -23,8 +23,6 @@ permalink: /blog/social/
 
           {% if post.image %}
             <img src="{{ site.baseurl }}{{ post.image }}" alt="">
-            {% else %}
-            <img src="{{ site.baseurl }}/img/blog/typelevel-placeholder.png" alt="">
             {% endif %}
 
 

--- a/blog/summits.html
+++ b/blog/summits.html
@@ -21,8 +21,6 @@ permalink: /blog/summits/
         <div class="blog-item-content">
             {% if post.image %}
             <img src="{{ site.baseurl }}{{ post.image }}" alt="">
-            {% else %}
-            <img src="{{ site.baseurl }}/img/blog/typelevel-placeholder.png" alt="">
             {% endif %}
 
 

--- a/blog/technical.html
+++ b/blog/technical.html
@@ -23,8 +23,6 @@ permalink: /blog/technical/
 
           {% if post.image %}
             <img src="{{ site.baseurl }}{{ post.image }}" alt="">
-            {% else %}
-            <img src="{{ site.baseurl }}/img/blog/typelevel-placeholder.png" alt="">
             {% endif %}
 
 


### PR DESCRIPTION
We don't currently have any images for our blog posts, so everything uses the placeholder image, which I don't think adds value.

Before:

<img width="1293" alt="with-placeholders" src="https://user-images.githubusercontent.com/5440389/210598660-786473c1-dad2-4b4f-aa49-29780a039ee4.png">


After:

<img width="1293" alt="no-placeholders" src="https://user-images.githubusercontent.com/5440389/210598231-fe037cc3-b657-4531-bf92-989717a031dc.png">

Previous discussion: https://github.com/typelevel/typelevel.github.com/issues/348

Tagged a handful of folks who have worked on the site in the past, but I'm happy to hear thoughts from everyone :).