### PR TITLE
Remove animation on all pages

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -11,7 +11,6 @@
 
   <!-- Custom CSS -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/monokai.min.css">
-  <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
   <link rel="stylesheet" href="{{ '/css/main.css' | relative_url }}">
 
   <link rel="alternate" type="application/rss+xml" title="Blog articles" href="{% link blog/feed.rss %}" />

--- a/_includes/_js-bottom.html
+++ b/_includes/_js-bottom.html
@@ -2,9 +2,3 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"></script>
 <script>hljs.highlightAll();</script>
 <script src="https://kit.fontawesome.com/a7055d991d.js" crossorigin="anonymous"></script>
-<script src="https://unpkg.com/aos@next/dist/aos.js"></script>
-<script>
-  AOS.init({
-    duration: 700
-  });
-</script>

--- a/_includes/_masthead.html
+++ b/_includes/_masthead.html
@@ -1,7 +1,7 @@
 <section id="masthead">
   <div class="container">
     <div class="masthead-inner">
-      <div class="masthead-text" data-aos="fade-right">
+      <div class="masthead-text">
         <h1><span>{{ site.title }}</span></h1>
         <p>{{ site.description }}</p>
         <div class="masthead-cta">
@@ -9,7 +9,7 @@
           <a class="button button-primary" href="{{ site.baseurl }}/about/">About</a>
         </div>
       </div>
-      <div class="masthead-image" data-aos="fade-down">
+      <div class="masthead-image">
         <svg class="masthead-image-path" width="214px" height="217px">
           <polygon fill="#FE4559"
             points="0.100965794 125.225045 0.100965794 216.172414 213.283516 91.1197822 213.283516 0.172413793">

--- a/_includes/_section-blog.html
+++ b/_includes/_section-blog.html
@@ -6,7 +6,7 @@
     </div>
     <div class="blog-list">
       {% for post in site.posts limit:3 %}
-      <a href="{{ post.url | relative_url }}" class="blog-item" data-aos="fade-down">
+      <a href="{{ post.url | relative_url }}" class="blog-item">
         <div class="blog-item-content">
           {% if post.image %}
           <img src="{{ site.baseurl }}{{ post.image }}" alt="">

--- a/_includes/_section-projects.html
+++ b/_includes/_section-projects.html
@@ -7,7 +7,7 @@
     <div class="projects-list">
       {% assign projects = site.projects | where:'core', true %}
       {% for project in projects limit:3 %}
-      <a href="{{ project.github }}" class="project-item" data-aos="fade-down">
+      <a href="{{ project.github }}" class="project-item">
         <div class="project-item-content">
           <div>
             <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">

--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -19,30 +19,6 @@
       //background: $brand-primary;
       padding: 0 $base-point-grid * 18;
     }
-
-    &:nth-child(1) {
-      transition-delay: 0.1s;
-    }
-
-    &:nth-child(2) {
-      transition-delay: 0.2s;
-    }
-
-    &:nth-child(3) {
-      transition-delay: 0.3s;
-    }
-
-    &:nth-child(4) {
-      transition-delay: 0.4s;
-    }
-
-    &:nth-child(5) {
-      transition-delay: 0.5s;
-    }
-
-    &:nth-child(6) {
-      transition-delay: 0.6s;
-    }
   }
 }
 

--- a/about/index.html
+++ b/about/index.html
@@ -23,7 +23,7 @@ title: About
 
     <div class="about-list">
       {% for item in site.data.about %}
-      <div class="about-item" data-aos="fade-down">
+      <div class="about-item">
         <img src="{{ site.baseurl }}{{ item.icon }}" title="{{ item.title }}" />
         <h3>{{item.title}}</h3>
         <p>{{item.description}}</p>


### PR DESCRIPTION
Removes the "animate on scroll" animation of the hexagons on the About page.

I don't have a preview for this... because it's hard. Just trust me, there's no animation.

This is clearly a personal preference thing, but I would like to ditch all animation across the whole site.

Update: This PR now removes all animation effects from the site.