### PR TITLE
Add Platforms Tags and Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ To add
 
 ### Adding a page
 
-To add a page, create a directory in the root of the project, with at least an `index.html` file in that directory. The site navigation is not fully dynamic for simplification purposes. The new page can be added to the nav by updating `_data/nav.yml`.
+To add a page, 
+
+1. Create a directory in the root of the project, with at least an `index.html` file in that directory. 2. Update  `_data/nav.yml` to add it to the navigation. (The site navigation is not fully dynamic for simplification.)
 
 Sample front matter for a page:
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ If you haven't written a post before, please add yourself to `_data/authors.yml`
 
 That's it, we'll take care of the rest. If you wish, you can also submit just a plain Markdown file and we'll be happy to integrate it.
 
-You can also use `tut` in posts. See `posts/2016-09-30-subtype-typeclasses.md` for an example.
-
 ### Previewing your changes
 
 #### Bundler
@@ -97,18 +95,16 @@ Unless otherwise noted, all website content is licensed under a [Creative Common
 
 ### CSS
 
-The stylesheets are written in SASS, and can be found in the `css` and `_scss` directories.
+The stylesheets are written in SASS, and can be found in the `css` and `_sass` directories.
 It is being processed/compiled into regular CSS by Jekyll.
 
 ```
 ├── css/
 │   ├── main.scss # Custom CSS, brings all stylesheets together
-├── _scss/
-│   ├── _fonts.scss # @font-face embedding.
-│   ├── _mixins.scss # SASS mixins
-│   ├── _reset.scss # Normalize stylesheet
-│   ├── _syntax.scss # Syntax highlighting by Pygments
-│   ├── _variables.scss # SASS variables (colors, fonts, etc.)
+├── _sass/
+│   ├── base/
+│   ├── components/
+│   ├── utils/
 ```
 
 ### Javascript
@@ -125,41 +121,27 @@ Images for styling purposes are located inside `img/`, photos inside `img/media/
 
 ### Adding a project
 
-There are four types of projects: core/featured projects, regular projects, incubator projects, and macros.
+There are three types of projects: organization projects, affiliate projects, and core/featured projects.
 
-To add a regular project, create a new markdown file in the `_projects` folder with the following front matter:
+To add an organization project, insert a new entry, alphabetically, in the `_data/projects.yml` file with the following keys:
 
 ```yml
-layout: post
-title: "Cats"
-description: "An experimental library intended to provide abstractions for functional programming in Scala, leveraging its unique features. Design goals are approachability, modularity, documentation and efficiency."
-permalink: "https://non.github.io/cats/"
-github: "https://github.com/non/cats"
+- title: "Cats"
+  description: "An experimental library intended to provide abstractions for functional programming in Scala, leveraging its unique features. Design goals are approachability, modularity, documentation and efficiency."
+  github: "https://github.com/non/cats"
+  platforms: [js, jvm, native]
+  permalink: "https://non.github.io/cats" # optional
 ```
 
 Right now nothing more than the correct front matter is required.
 
-Do the same for a **core/featured** project, but also add `core: true`.
-To add companions or extensions to these projects, use the front matter, too:
-
-```yml
-extensions:
-  - title: "Alleycats"
-    description: "Lawless classes & illegal instances"
-    github: "https://github.com/non/alleycats"
-```
-
-Incubator projects and macros are created a little differently. They are located in `_data/incubator.yml` and `_data/macros.yml` respectively, and look like this:
-
-```yml
-- title: "imp"
-  description: "Summoning implicit values"
-  github: "https://github.com/non/imp"
-```
+To add an:
+- **affiliate** project, add `affiliate: true` to the project entry
+- **core** project, add `core: true` to the project entry
 
 ### Adding a page
 
-To add a page, create a HTML or Markdown file in the root of the project. The site navigation is not fully dynamic for simplification purposes. It can be changed in the default layout (`_layouts/default.html`).
+To add a page, create a directory in the root of the project, with at least an `index.html` file in that directory. The site navigation is not fully dynamic for simplification purposes. The new page can be added to the nav by updating `_data/nav.yml`.
 
 Sample front matter for a page:
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ To add a regular project, create a new markdown file in the `_projects` folder w
 ```yml
 layout: post
 title: "Cats"
-category: "Functional Programming"
 description: "An experimental library intended to provide abstractions for functional programming in Scala, leveraging its unique features. Design goals are approachability, modularity, documentation and efficiency."
 permalink: "https://non.github.io/cats/"
 github: "https://github.com/non/cats"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ To add
 
 To add a page, 
 
-1. Create a directory in the root of the project, with at least an `index.html` file in that directory. 2. Update  `_data/nav.yml` to add it to the navigation. (The site navigation is not fully dynamic for simplification.)
+1. Create a directory in the root of the project, with at least an `index.html` file in that directory. 
+2. Update  `_data/nav.yml` to add it to the navigation. (The site navigation is not fully dynamic for simplification.)
 
 Sample front matter for a page:
 

--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ To add an organization project, insert a new entry, alphabetically, in the `_dat
 
 Right now nothing more than the correct front matter is required.
 
-To add an:
-- **affiliate** project, add `affiliate: true` to the project entry
-- **core** project, add `core: true` to the project entry
+To add
+- an **affiliate** project, add `affiliate: true` to the project entry
+- a **core** project, add `core: true` to the project entry
 
 ### Adding a page
 

--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ To add an organization project, insert a new entry, alphabetically, in the `_dat
 
 ```yml
 - title: "Cats"
-  description: "An experimental library intended to provide abstractions for functional programming in Scala, leveraging its unique features. Design goals are approachability, modularity, documentation and efficiency."
-  github: "https://github.com/non/cats"
+  description: "A library intended to provide abstractions for functional programming in Scala, leveraging its unique features. Design goals are approachability, modularity, documentation and efficiency."
+  github: "https://github.com/typelevel/cats"
   platforms: [js, jvm, native]
-  permalink: "https://non.github.io/cats" # optional
+  permalink: "https://typelevel.org/cats/" # optional
 ```
 
 Right now nothing more than the correct front matter is required.

--- a/_data/description.yml
+++ b/_data/description.yml
@@ -4,10 +4,6 @@ aboutDescription: Learn more about the organization, including our main goals, c
 projectsTitle: Projects
 projectsDescription: Our projects cover a wide range of domains, from general functional programming to tooling.
 
-platformsTitle: Platforms
-platformsDescription: Checkout the Typelevel ecosystem by platform.
-jsDescription: Checkout Typelevel on Scala.js!
-
 blogTitle: Latest blog posts
 blogDescription: In addition to org-level announcements, here we show you how to use our libraries in your code, provide examples, collect learning resources, and explore implementation details.
 

--- a/_data/description.yml
+++ b/_data/description.yml
@@ -6,7 +6,7 @@ projectsDescription: Our projects cover a wide range of domains, from general fu
 
 platformsTitle: Platforms
 platformsDescription: Checkout the Typelevel ecosystem by platform.
-jsDescription: Checkout Typelevel on ScalaJS!
+jsDescription: Checkout Typelevel on Scala.js!
 
 blogTitle: Latest blog posts
 blogDescription: In addition to org-level announcements, here we show you how to use our libraries in your code, provide examples, collect learning resources, and explore implementation details.

--- a/_data/description.yml
+++ b/_data/description.yml
@@ -4,6 +4,10 @@ aboutDescription: Learn more about the organization, including our main goals, c
 projectsTitle: Projects
 projectsDescription: Our projects cover a wide range of domains, from general functional programming to tooling.
 
+platformsTitle: Platforms
+platformsDescription: Checkout the Typelevel ecosystem by platform.
+jsDescription: Checkout Typelevel on ScalaJS!
+
 blogTitle: Latest blog posts
 blogDescription: In addition to org-level announcements, here we show you how to use our libraries in your code, provide examples, collect learning resources, and explore implementation details.
 

--- a/_data/filter-platforms.yml
+++ b/_data/filter-platforms.yml
@@ -1,9 +1,9 @@
-- title: JVM
-  url: /platforms/jvm/
-  category: jvm
 - title: JS
   url: /platforms/js/
   category: js
+- title: JVM
+  url: /platforms/jvm/
+  category: jvm
 - title: Native
   url: /platforms/native/
   category: native

--- a/_data/filter-platforms.yml
+++ b/_data/filter-platforms.yml
@@ -1,0 +1,9 @@
+- title: JVM
+  url: /platforms/jvm/
+  category: jvm
+- title: JS
+  url: /platforms/js/
+  category: js
+- title: Native
+  url: /platforms/native/
+  category: native

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -5,6 +5,9 @@ navMain:
   - title: Projects
     url: /projects/
 
+  - title: Platforms
+    url: /platforms/
+
   - title: Blog
     url: /blog/
 

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -26,7 +26,6 @@
   github: "https://github.com/typelevel/catbird"
   platforms: [jvm]
 - title: "Cats"
-  category: "Functional Programming"
   description: "A library intended to provide abstractions for functional programming in Scala, leveraging its unique features. Design goals are approachability, modularity, documentation and efficiency."
   permalink: "https://typelevel.org/cats/"
   github: "https://github.com/typelevel/cats"
@@ -77,31 +76,26 @@
   affiliate: true
   platforms: [js, jvm]
 - title: "decline"
-  category: "Command-line parsing"
   description: "A composable command-line parser for Scala."
   github: "https://github.com/bkirwi/decline"
   affiliate: true
   platforms: [js, jvm, native]
 - title: "discipline"
-  category: "Flexible law checking"
   description: "Originally intended for internal use in spire, this library helps libraries declaring type classes to precisely state the laws which instances need to satisfy, and takes care of not checking derived laws multiple times."
   github: "https://github.com/typelevel/discipline"
   platforms: [js, jvm, native]
 - title: "doobie"
-  category: "Principled database access"
   description: "A pure functional JDBC layer for Scala. It is not an ORM, nor is it a relational algebra; it just provides a principled way to construct programs (and higher-level libraries) that use JDBC."
   github: "https://github.com/tpolecat/doobie"
   affiliate: true
   platforms: [jvm]
 - title: "edomata"
-  category: "Event sourcing and CQRS"
   description: "Event-driven automata for Scala, Scala.js and scala native. This library provides purely functional state machines that can be used to create event sourced and/or CQRS style applications. It also includes production ready backends."
   github: "https://github.com/hnaderi/edomata"
   permalink: "https://edomata.ir/"
   affiliate: true
   platforms: [js, jvm, native]
 - title: "eff"
-  category: "effects"
   description: "Extensible effects are an alternative to monad transformers for computing with effects in a functional way. This library is based on the “free-er” monad and an “open union” of effects described by Oleg Kiselyov in “Freer monads, more extensible effects”"
   
   permalink: "http://atnos-org.github.io/eff"
@@ -120,7 +114,6 @@
   affiliate: true
   platforms: [jvm]
 - title: "fabric"
-  category: "JSON Library"
   description: "Object-Notation Abstraction for JSON, binary, HOCON, etc."
   github: "https://github.com/typelevel/fabric"
   platforms: [js, jvm, native]
@@ -135,18 +128,15 @@
   affiliate: true
   platforms: [jvm]
 - title: "Frameless"
-  category: "Typeful Spark"
   description: "Frameless is a library for working with Spark using more expressive types."
   github: "https://github.com/typelevel/frameless"
   platforms: [jvm]
 - title: "fs2-compress"
-  category: "Stream Processing"
   description: "Compression Algorithms for Fs2 "
   github: "https://github.com/lhns/fs2-compress"
   affiliate: true
   platforms: [jvm]
 - title: "fs2-data"
-  category: "Stream Processing"
   description: "Parse and transform data (CBOR, CSV, JSON, XML) in a streaming manner"
   github: "https://github.com/gnieh/fs2-data"
   affiliate: true
@@ -161,7 +151,6 @@
   github: "https://github.com/typelevel/fs2-grpc"
   platforms: [jvm]
 - title: "fs2"
-  category: "Stream Processing"
   description: "FS2 is a library for purely functional, effectful, and polymorphic stream processing library in the Scala programming language. Its design goals are compositionality, expressiveness, resource safety, and speed. The name is a modified acronym for Functional Streams for Scala (FSS, or FS2)."
   github: "https://github.com/typelevel/fs2"
   platforms: [js, jvm, native]
@@ -198,7 +187,6 @@
   affiliate: true
   platforms: [js, jvm, native]
 - title: "Lepus"
-  category: "Principled AMQP client"
   description: "Purely functional, non-blocking RabbitMQ client for scala, scala js and scala native built on top of fs2."
   github: "https://github.com/hnaderi/lepus"
   permalink: "https://lepus.hnaderi.dev/"
@@ -214,14 +202,12 @@
   github: "https://github.com/typelevel/log4cats"
   platforms: [js, jvm, native]
 - title: "Monix"
-  category: "Asynchronous, Reactive Programming"
   description: "High-performance library for composing asynchronous, event-based programs, exposing a Reactive Streams implementation along with primitives for dealing with concurrency and side-effects."
   github: "https://github.com/monix/monix"
   permalink: "https://monix.io"
   affiliate: true
   platforms: [js, jvm]
 - title: "Monocle"
-  category: "Lenses for Scala"
   description: "Optics library offering a simple yet powerful API to access and transform immutable data"
   github: "https://github.com/optics-dev/Monocle"
   affiliate: true
@@ -254,13 +240,11 @@
   affiliate: true
   platforms: [jvm]
 - title: "refined"
-  category: "Constraints on types"
   description: "Tools for refining types with type-level predicates which constrain the set of values described by the refined type, for example restricting to positive or negative numbers."
   github: "https://github.com/fthomas/refined"
   affiliate: true
   platforms: [js, jvm, native]
 - title: "ScalaCheck"
-  category: "Property checking"
   description: "ScalaCheck is a library for automated property-based testing. It contains generators for randomized test data and combinators for properties."
   github: "https://github.com/typelevel/scalacheck"
   permalink: "http://scalacheck.org/"
@@ -281,7 +265,6 @@
   affiliate: true
   platforms: [jvm]
 - title: "scodec"
-  category: "Binary serialization"
   description: "scodec is a combinator library for working with binary data. It focuses on contract-first and pure functional encoding and decoding of binary data and provides integration with shapeless."
   github: "https://github.com/scodec/scodec"
   affiliate: true
@@ -292,7 +275,6 @@
   affiliate: true
   platforms: [js, jvm, native]
 - title: "Shapeless"
-  category: "Generic Programming"
   description: "Shapeless is a generic programming library. Starting with implementations of Scrap your boilerplate and higher rank polymorphism in Scala, it quickly grew to provide advanced abstract tools like heterogenous lists and automatic instance derivation for type classes."
   github: "https://github.com/milessabin/shapeless"
   affiliate: true
@@ -322,14 +304,12 @@
   affiliate: true
   platforms: [jvm]
 - title: "specs2"
-  category: "Expressive specifications"
   description: "specs2 is a library for writing executable software specifications, aiming for conciseness, readability and extensibility."
   github: "https://github.com/etorreborre/specs2"
   permalink: "http://specs2.org/"
   affiliate: true
   platforms: [js, jvm, native]
 - title: "spire"
-  category: "Numeric abstractions"
   description: "Spire is a numeric library for Scala which is intended to be generic, fast, and precise. Using features such as specialization, macros, type classes, and implicits, Spire works hard to defy conventional wisdom around performance and precision trade-offs."
   github: "https://github.com/typelevel/spire"
   core: true

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -154,131 +154,163 @@
 - title: "keypool"
   description: "A Keyed Pool Implementation for Scala"
   github: "https://github.com/typelevel/keypool"
+  platforms: [js, jvm, native]
 - title: "kind-projector"
   description: "Plugin for nicer type-lambda syntax"
   github: "https://github.com/non/kind-projector"
+  platforms: [jvm]
 - title: "Kittens"
   description: "Automatic type class derivation"
   github: "https://github.com/milessabin/kittens"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "Libra"
   description: "Compile time dimensional analysis for any problem domain"
   github: "https://github.com/to-ithaca/libra"
   affiliate: true
+  platforms: [js, jvm]
 - title: "log4cats"
   description: "Logging Tools For Interaction with cats-effect"
   github: "https://github.com/typelevel/log4cats"
+  platforms: [js, jvm, native]
 - title: "Monix"
   category: "Asynchronous, Reactive Programming"
   description: "High-performance library for composing asynchronous, event-based programs, exposing a Reactive Streams implementation along with primitives for dealing with concurrency and side-effects."
   github: "https://github.com/monix/monix"
   permalink: "https://monix.io"
   affiliate: true
+  platforms: [js, jvm]
 - title: "Monocle"
   category: "Lenses for Scala"
   description: "Strongly inspired by Haskell's lens library, Monocle is an Optics library where Optics gather the concepts of Lens, Traversal, Optional, Prism and Iso."
   github: "https://github.com/julien-truffaut/Monocle"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "Mouse"
   description: "Enrichments to standard library classes to ease functional programming"
   github: "https://github.com/typelevel/mouse/"
+  platforms: [js, jvm, native]
 - title: "otel4s"
   description: "An OpenTelemetry library based on cats-effect"
   github: "https://github.com/typelevel/otel4s"
+  platforms: [js, jvm, native]
 - title: "Outwatch"
   description: "The Functional and Reactive Web-Frontend Library for Scala.js"
   github: "https://github.com/outwatch/outwatch"
   affiliate: true
+  platforms: [js]
 - title: "parsley-cats"
   description: "The parsley-cats library exposes Cats instances for Parsley parsing library."
   github: "https://github.com/j-mie6/parsley-cats"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "PureConfig"
   description: "A boilerplate-free library for loading configuration files"
   github: "https://github.com/pureconfig/pureconfig"
   affiliate: true
+  platforms: [jvm]
 - title: "refined"
   category: "Constraints on types"
   description: "Tools for refining types with type-level predicates which constrain the set of values described by the refined type, for example restricting to positive or negative numbers."
   github: "https://github.com/fthomas/refined"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "ScalaCheck"
   category: "Property checking"
   description: "ScalaCheck is a library for automated property-based testing. It contains generators for randomized test data and combinators for properties."
   github: "https://github.com/rickynils/scalacheck"
   permalink: "http://scalacheck.org/"
+  platforms: [js, jvm, native]
 - title: "scalacheck-shapeless"
   description: "Automatic derivation for ScalaCheck"
   github: "https://github.com/alexarchambault/scalacheck-shapeless"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "Scala Exercises"
   description: "Platform and framework for Scala devs to learn about Scala libraries"
   github: "https://github.com/scala-exercises/scala-exercises"
   affiliate: true
+  platforms: [js, jvm]
 - title: "scala-steward"
   description: "A robot that helps keeping Scala projects up-to-date"
   github: "https://github.com/fthomas/scala-steward"
   affiliate: true
+  platforms: [jvm]
 - title: "scodec"
   category: "Binary serialization"
   description: "scodec is a combinator library for working with binary data. It focuses on contract-first and pure functional encoding and decoding of binary data and provides integration with shapeless."
   github: "https://github.com/scodec/scodec"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "Scoverage"
   description: "Code coverage tool for Scala"
   github: "https://github.com/scoverage/scalac-scoverage-plugin"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "Shapeless"
   category: "Generic Programming"
   description: "Shapeless is a generic programming library. Starting with implementations of Scrap your boilerplate and higher rank polymorphism in Scala, it quickly grew to provide advanced abstract tools like heterogenous lists and automatic instance derivation for type classes."
   github: "https://github.com/milessabin/shapeless"
   affiliate: true
   core: true
+  platforms: [js, jvm, native]
 - title: "simulacrum"
   description: "First-class syntax for type classes"
   github: "https://github.com/mpilquist/simulacrum"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "Simulacrum Scalafix"
   description: "Simulacrum as Scalafix rules"
   github: "https://github.com/typelevel/simulacrum-scalafix"
+  platforms: [js, jvm]
 - title: "singleton-ops"
   description: "Operations for primitive and String singleton types"
   github: "https://github.com/fthomas/singleton-ops"
   affiliate: true
+  platforms: [js, jvm]
 - title: "sonic"
   description: "Property-based testing with integrated shrinking"
   github: "https://github.com/melrief/sonic"
   affiliate: true
+  platforms: [jvm]
 - title: "specs2"
   category: "Expressive specifications"
   description: "specs2 is a library for writing executable software specifications, aiming for conciseness, readability and extensibility."
   github: "https://github.com/etorreborre/specs2"
   permalink: "http://specs2.org/"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "spire"
   category: "Numeric abstractions"
   description: "Spire is a numeric library for Scala which is intended to be generic, fast, and precise. Using features such as specialization, macros, type classes, and implicits, Spire works hard to defy conventional wisdom around performance and precision trade-offs."
   github: "https://github.com/non/spire"
   affiliate: true
   core: true
+  platforms: [js, jvm, native]
 - title: "Squants"
   description: "The Scala API for Quantities, Units of Measure and Dimensional Analysis"
   github: "https://github.com/garyKeorkunian/squants"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "TwoTails"
   description: "A compiler plugin adding support for mutual tail recursion"
   github: "https://github.com/wheaties/TwoTails"
   affiliate: true
+  platforms: [jvm]
 - title: "typelevel.g8"
   description: "A Giter8 template for sbt-typelevel"
   github: "https://github.com/typelevel/typelevel.g8"
+  platforms: [js, jvm]
 - title: "typelevel-nix"
   description: "Development tools for Typelevel projects"
   github: "https://github.com/typelevel/typelevel-nix"
+  platforms: [js, jvm, native]
 - title: "uniform-scala"
   description: "Functional user journeys"
   github: "https://github.com/ltbs/uniform-scala"
   affiliate: true
+  platforms: [js, jvm]
 - title: "vault"
   description: "Type-safe, persistent storage for values of arbitrary types"
   github: "https://github.com/typelevel/vault"
+  platforms: [js, jvm, native]

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -2,56 +2,71 @@
   description: "Automatic derivation for argonaut"
   github: "https://github.com/alexarchambault/argonaut-shapeless"
   affiliate: true
+  platforms: [jvm]
 - title: "banana-rdf"
   description: "RDF, SPARQL and Linked Data technologies"
   github: "https://github.com/banana-rdf/banana-rdf"
   affiliate: true
+  platforms: [js, jvm]
 - title: "case-insensitive"
   description: "A case-insensitive string for Scala"
   github: "https://github.com/typelevel/case-insensitive"
+  platforms: [js, jvm, native]
 - title: "catbird"
   description: "Cats instances for various Twitter Open Source Scala projects"
   github: "https://github.com/typelevel/catbird"
+  platforms: [jvm]
 - title: "Cats"
   category: "Functional Programming"
   description: "A library intended to provide abstractions for functional programming in Scala, leveraging its unique features. Design goals are approachability, modularity, documentation and efficiency."
   permalink: "https://typelevel.org/cats/"
   github: "https://github.com/typelevel/cats"
   core: true
+  platforms: [js, jvm, native]
 - title: "Cats Collections"
   description: "Data structures that facilitate pure functional programming with cats"
   github: "https://github.com/typelevel/cats-collections"
+  platforms: [js, jvm, native]
 - title: Cats-Effect
   description: "The IO Monad for Scala, plus type classes for general effect types."
   github: "https://github.com/typelevel/cats-effect/"
+  platforms: [js, jvm, native]
 - title: "Cats MTL"
   description: "Monad transformers made easy"
   github: "https://github.com/typelevel/cats-mtl/"
+  platforms: [js, jvm, native]
 - title: "cats-parse"
   description: "A parsing library for the cats ecosystem"
   github: "https://github.com/typelevel/cats-parse"
+  platforms: [js, jvm, native]
 - title: "cats-scalatest"
   description: "Scalatest bindings for Cats."
   github: "https://github.com/IronCoreLabs/cats-scalatest"
   affiliate: true
+  platforms: [js, jvm]
 - title: "Cats Tagless"
   description: "A library of utilities for tagless final algebras"
   github: "https://github.com/typelevel/cats-tagless/"
+  platforms: [js, jvm, native]
 - title: "Cats-Time"
   description: "Instances for Cats Typeclasses for Java 8 Time"
   github: "https://github.com/ChristopherDavenport/cats-time"
+  platforms: [js, jvm, native]
 - title: "Ciris"
   description: "Functional Configurations for Scala"
   github: "https://github.com/vlovgr/ciris"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "coulomb"
   description: "A statically typed unit analysis library for Scala"
   github: "https://github.com/erikerlandson/coulomb"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "cron4s"
   description: "Cross-platform CRON expression parsing for Scala"
   github: "https://github.com/alonsodomin/cron4s"
   affiliate: true
+  platforms: [js, jvm]
 - title: "decline"
   category: "Command-line parsing"
   description: "A composable command-line parser for Scala."

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -72,15 +72,18 @@
   description: "A composable command-line parser for Scala."
   github: "https://github.com/bkirwi/decline"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "discipline"
   category: "Flexible law checking"
   description: "Originally intended for internal use in spire, this library helps libraries declaring type classes to precisely state the laws which instances need to satisfy, and takes care of not checking derived laws multiple times."
   github: "https://github.com/typelevel/discipline"
+  platforms: [js, jvm, native]
 - title: "doobie"
   category: "Principled database access"
   description: "A pure functional JDBC layer for Scala. It is not an ORM, nor is it a relational algebra; it just provides a principled way to construct programs (and higher-level libraries) that use JDBC."
   github: "https://github.com/tpolecat/doobie"
   affiliate: true
+  platforms: [jvm]
 - title: "eff"
   category: "effects"
   description: "Extensible effects are an alternative to monad transformers for computing with effects in a functional way. This library is based on the “free-er” monad and an “open union” of effects described by Oleg Kiselyov in “Freer monads, more extensible effects”"
@@ -88,53 +91,66 @@
   permalink: "http://atnos-org.github.io/eff"
   github: "https://github.com/atnos-org/eff"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "Extruder"
   description: "Populate case classes from any configuration source"
   github: "https://github.com/janstenpickle/extruder"
   affiliate: true
+  platforms: [jvm]
 - title: "fabric"
   category: "JSON Library"
   description: "Object-Notation Abstraction for JSON, binary, HOCON, etc."
   github: "https://github.com/typelevel/fabric"
+  platforms: [js, jvm, native]
 - title: "Fetch"
   description: "Library built on top of Cats that provides efficient data access from heterogeneous dataurces"
   github: "https://github.com/47deg/fetch"
   affiliate: true
+  platforms: [js, jvm]
 - title: "Finch"
   description: "Purely functional basic blocks atop of Finagle for building composable HTTP APIs"
   github: "https://github.com/finagle/finch"
   affiliate: true
+  platforms: [jvm]
 - title: "Frameless"
   category: "Typeful Spark"
   description: "Frameless is a library for working with Spark using more expressive types."
   github: "https://github.com/typelevel/frameless"
+  platforms: [jvm]
 - title: "fs2-data"
   category: "Stream Processing"
   description: "Parse and transform data (CBOR, CSV, JSON, XML) in a streaming manner"
   github: "https://github.com/gnieh/fs2-data"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "fs2-grpc"
   description: "gRPC implementation for FS2/cats-effect"
   github: "https://github.com/typelevel/fs2-grpc"
+  platforms: [jvm]
 - title: "fs2"
   category: "Stream Processing"
   description: "FS2 is a library for purely functional, effectful, and polymorphic stream processing library in the Scala programming language. Its design goals are compositionality, expressiveness, resource safety, and speed. The name is a modified acronym for Functional Streams for Scala (FSS, or FS2)."
   github: "https://github.com/functional-streams-for-scala/fs2"
+  platforms: [js, jvm, native]
 - title: "Hammock"
   description: "Purely functional HTTP client"
   github: "https://github.com/pepegar/hammock"
   affiliate: true
+  platforms: [jvm]
 - title: "http4s"
   description: "A typeful, purely functional HTTP library for client and server applications"
   github: "https://github.com/http4s/http4s"
   affiliate: true
+  platforms: [js, jvm, native]
 - title: "imp"
   description: "Summoning implicit values"
   github: "https://github.com/non/imp"
   affiliate: true
+  platforms: [js, jvm]
 - title: "jawn-fs2"
   description: "Integration of jawn and fs2 for streaming, incremental JSON parsing"
   github: "https://github.com/typelevel/jawn-fs2"
+  platforms: [js, jvm, native]
 - title: "keypool"
   description: "A Keyed Pool Implementation for Scala"
   github: "https://github.com/typelevel/keypool"

--- a/_includes/_project_platforms_tag.html
+++ b/_includes/_project_platforms_tag.html
@@ -1,0 +1,3 @@
+<div class="project-item-tag">
+  <p>{{ project.platforms | join: " / "}}</p>
+</div>

--- a/_includes/_section-projects.html
+++ b/_includes/_section-projects.html
@@ -15,18 +15,8 @@
           </div>
           <p>{{ project.description }}</p>
         </div>
-        {% if project.category %}
-        <div class="project-item-tag">
-          <p>{{ project.category }}</p>
-        </div>
-        {% endif %}
-        <div class="project-membership">
-          {% if project.affiliate %}
-          <img src="https://img.shields.io/badge/typelevel-affiliate-FFB4B5" alt="Typelevel affiliate" />
-          {% else %}
-          <img src="https://img.shields.io/badge/typelevel-member-FF6169" alt="Typelevel member" />
-          {% endif %}
-        </div>
+        {% include _project_platforms_tag.html %}
+        {% include _project_membership.html %}
       </a>
       {% endfor %}
     </div>

--- a/_includes/_tab-platforms.html
+++ b/_includes/_tab-platforms.html
@@ -1,0 +1,5 @@
+<ul class="tab">
+    {% for tabItem in site.data.filter-platforms %}
+    <li><a href="{{ site.baseurl }}{{tabItem.url}}" {% if tabItem.url == page.url %} class="active" {% endif %}>{{tabItem.title}}</a></li>
+    {% endfor %}
+</ul>

--- a/_includes/_tab-platforms.html
+++ b/_includes/_tab-platforms.html
@@ -1,5 +1,0 @@
-<ul class="tab">
-    {% for tabItem in site.data.filter-platforms %}
-    <li><a href="{{ site.baseurl }}{{tabItem.url}}" {% if tabItem.url == page.url %} class="active" {% endif %}>{{tabItem.title}}</a></li>
-    {% endfor %}
-</ul>

--- a/platforms/index.html
+++ b/platforms/index.html
@@ -6,7 +6,7 @@ title: Platforms
   <div class="container">
     <div class="masthead-page">
       <h1><span>{{ page.title }}</span></h1>
-      <p>Checkout the Typelevel ecosystem by platform</p>
+      <p>Check out the Typelevel ecosystem by platform</p>
       {% include _tab-platforms.html %}
     </div>
   </div>

--- a/platforms/index.html
+++ b/platforms/index.html
@@ -7,11 +7,7 @@ title: Platforms
     <div class="masthead-page">
       <h1><span>{{ page.title }}</span></h1>
       <p>Checkout the Typelevel ecosystem by platform</p>
-      <ul class="tab">
-        {% for tabItem in site.data.filter-platforms %}
-          <li><a href="{{ site.baseurl }}{{tabItem.url}}">{{tabItem.title}}</a></li>
-        {% endfor %}
-      </ul>
+      {% include _tab-platforms.html %}
     </div>
   </div>
 </div>

--- a/platforms/index.html
+++ b/platforms/index.html
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Platforms
+---
+<div id="section-page">
+  <div class="container">
+    <div class="masthead-page">
+      <h1><span>{{ page.title }}</span></h1>
+      <p>Checkout the Typelevel ecosystem by platform</p>
+      <ul class="tab">
+        {% for tabItem in site.data.filter-platforms %}
+          <li><a href="{{ site.baseurl }}{{tabItem.url}}">{{tabItem.title}}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>

--- a/platforms/js.html
+++ b/platforms/js.html
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Typelevel.js
+permalink: /platforms/js/
+---
+
+<div id="section-page">
+  <div class="container">
+    <div class="masthead-page">
+      <h1><span>{{ page.title }}</span></h1>
+      <p>{{site.data.description.jsDescription}}</p>
+    </div>
+
+    <div class="projects-list">
+      {% for project in site.data.projects %}
+      {% if project.platforms contains "js" %}
+      <a href="{{ project.github }}" class="project-item">
+        <div class="project-item-content">
+          <div>
+            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
+            <h3>{{ project.title }}</h3>
+          </div>
+          <p>{{ project.description }}</p>
+        </div>
+        {% if project.category %}
+        <div class="project-item-tag">
+          <p>{{ project.category }}</p>
+        </div>
+        {% endif %}
+        {% include _project_membership.html %}
+      </a>
+      {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/platforms/js.html
+++ b/platforms/js.html
@@ -8,7 +8,12 @@ permalink: /platforms/js/
   <div class="container">
     <div class="masthead-page">
       <h1><span>{{ page.title }}</span></h1>
-      <p>{{site.data.description.jsDescription}}</p>
+      <p>
+        Much of the Typelevel ecosystem cross compiles to JavaScript via <a href="https://www.scala-js.org/">Scala.js</a>.
+        Deploy web servers on NodeJS with <a href="https://github.com/http4s/http4s">http4s</a>, <a href="https://github.com/typelevel/fs2">fs2</a>, and <a href="https://github.com/typelevel/cats-effect">cats-effect</a>.
+        Build reactive frontends with <a href="https://github.com/outwatch/outwatch">outwatch</a>, <a href="https://github.com/armanbilge/calico">calico</a>, and <a href="https://github.com/armanbilge/fs2-dom">fs2-dom</a>.
+      </p>
+
     </div>
 
     <div class="projects-list">

--- a/platforms/js.html
+++ b/platforms/js.html
@@ -14,6 +14,7 @@ permalink: /platforms/js/
         Build reactive frontends with <a href="https://github.com/outwatch/outwatch">outwatch</a>, <a href="https://github.com/armanbilge/calico">calico</a>, and <a href="https://github.com/armanbilge/fs2-dom">fs2-dom</a>.
       </p>
 
+      {% include _tab-platforms.html %}
     </div>
 
     <div class="projects-list">

--- a/platforms/js.html
+++ b/platforms/js.html
@@ -27,11 +27,7 @@ permalink: /platforms/js/
           </div>
           <p>{{ project.description }}</p>
         </div>
-        {% if project.category %}
-        <div class="project-item-tag">
-          <p>{{ project.category }}</p>
-        </div>
-        {% endif %}
+        {% include _project_platforms_tag.html %}
         {% include _project_membership.html %}
       </a>
       {% endif %}

--- a/platforms/jvm.html
+++ b/platforms/jvm.html
@@ -14,6 +14,7 @@ permalink: /platforms/jvm/
         Write functional JDBC programs with <a href="https://github.com/tpolecat/doobie">doobie</a>.
       </p>
 
+      {% include _tab-platforms.html %}
     </div>
 
     <div class="projects-list">

--- a/platforms/jvm.html
+++ b/platforms/jvm.html
@@ -27,11 +27,7 @@ permalink: /platforms/jvm/
           </div>
           <p>{{ project.description }}</p>
         </div>
-        {% if project.category %}
-        <div class="project-item-tag">
-          <p>{{ project.category }}</p>
-        </div>
-        {% endif %}
+        {% include _project_platforms_tag.html %}
         {% include _project_membership.html %}
       </a>
       {% endif %}

--- a/platforms/jvm.html
+++ b/platforms/jvm.html
@@ -1,0 +1,41 @@
+---
+layout: page
+title: Typelevel JVM
+permalink: /platforms/jvm/
+---
+
+<div id="section-page">
+  <div class="container">
+    <div class="masthead-page">
+      <h1><span>{{ page.title }}</span></h1>
+      <p>
+        Run your Typelevel stack on the JVM.
+        Leverage <a href="https://github.com/typelevel/fs2">fs2</a> and <a href="https://github.com/typelevel/cats-effect">cats-effect</a> on the JVM for highly concurrent networked services.
+        Write functional JDBC programs with <a href="https://github.com/tpolecat/doobie">doobie</a>.
+      </p>
+
+    </div>
+
+    <div class="projects-list">
+      {% for project in site.data.projects %}
+      {% if project.platforms contains "jvm" %}
+      <a href="{{ project.github }}" class="project-item">
+        <div class="project-item-content">
+          <div>
+            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
+            <h3>{{ project.title }}</h3>
+          </div>
+          <p>{{ project.description }}</p>
+        </div>
+        {% if project.category %}
+        <div class="project-item-tag">
+          <p>{{ project.category }}</p>
+        </div>
+        {% endif %}
+        {% include _project_membership.html %}
+      </a>
+      {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/platforms/native.html
+++ b/platforms/native.html
@@ -14,6 +14,7 @@ permalink: /platforms/native/
         Learn more about Typelevel Native in the <a href="/blog/2022/09/19/typelevel-native.html">introductory blog post</a>.
       </p>
 
+      {% include _tab-platforms.html %}
     </div>
 
     <div class="projects-list">

--- a/platforms/native.html
+++ b/platforms/native.html
@@ -1,0 +1,41 @@
+---
+layout: page
+title: Typelevel Native
+permalink: /platforms/native/
+---
+
+<div id="section-page">
+  <div class="container">
+    <div class="masthead-page">
+      <h1><span>{{ page.title }}</span></h1>
+      <p>
+        Get closer to bare metal with the Typelevel stack on <a href="https://www.scala-native.org">Scala Native</a>.
+        Deploy web servers with <a href="https://github.com/http4s/http4s">http4s</a>, <a href="https://github.com/typelevel/fs2">fs2</a>, and <a href="https://github.com/typelevel/cats-effect">cats-effect</a>.
+        Learn more about Typelevel Native in the <a href="/blog/2022/09/19/typelevel-native.html">introductory blog post</a>.
+      </p>
+
+    </div>
+
+    <div class="projects-list">
+      {% for project in site.data.projects %}
+      {% if project.platforms contains "native" %}
+      <a href="{{ project.github }}" class="project-item">
+        <div class="project-item-content">
+          <div>
+            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
+            <h3>{{ project.title }}</h3>
+          </div>
+          <p>{{ project.description }}</p>
+        </div>
+        {% if project.category %}
+        <div class="project-item-tag">
+          <p>{{ project.category }}</p>
+        </div>
+        {% endif %}
+        {% include _project_membership.html %}
+      </a>
+      {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/platforms/native.html
+++ b/platforms/native.html
@@ -27,11 +27,7 @@ permalink: /platforms/native/
           </div>
           <p>{{ project.description }}</p>
         </div>
-        {% if project.category %}
-        <div class="project-item-tag">
-          <p>{{ project.category }}</p>
-        </div>
-        {% endif %}
+        {% include _project_platforms_tag.html %}
         {% include _project_membership.html %}
       </a>
       {% endif %}

--- a/projects/affiliate.html
+++ b/projects/affiliate.html
@@ -23,11 +23,7 @@ permalink: /projects/affiliate/
           </div>
           <p>{{ project.description }}</p>
         </div>
-        {% if project.category %}
-        <div class="project-item-tag">
-          <p>{{ project.category }}</p>
-        </div>
-        {% endif %}
+        {% include _project_platforms_tag.html %}
         {% include _project_membership.html %}
       </a>
       {% endif %}

--- a/projects/index.html
+++ b/projects/index.html
@@ -19,11 +19,7 @@ title: Projects
           </div>
           <p>{{ project.description }}</p>
         </div>
-        {% if project.category %}
-        <div class="project-item-tag">
-          <p>{{ project.category }}</p>
-        </div>
-        {% endif %}
+        {% include _project_platforms_tag.html %}
         {% include _project_membership.html %}
       </a>
       {% endfor %}

--- a/projects/organization.html
+++ b/projects/organization.html
@@ -23,11 +23,7 @@ permalink: /projects/organization/
           </div>
           <p>{{ project.description }}</p>
         </div>
-        {% if project.category %}
-        <div class="project-item-tag">
-          <p>{{ project.category }}</p>
-        </div>
-        {% endif %}
+        {% include _project_platforms_tag.html %}
         {% include _project_membership.html %}
       </a>
       {% endif %}


### PR DESCRIPTION
**TLDR:**
- replaces `category` tag with `platform` tag
- page for each platform we support (JS, JVM, Native)


## Preview

While open, this PR is available for preview here:
https://valencik.github.io/typelevel.github.com/platforms/
(note however that some links will be broken there)

I recommend checkout out that preview because these screenshots are probably already out of data (they are).

![Screenshot 2023-04-22 at 10-13-19 Typelevel Typelevel js](https://user-images.githubusercontent.com/5440389/233789983-1bcb48f0-db04-4f6d-9f56-59f2d9260c33.png)

![Screenshot 2023-04-22 at 10-13-30 Typelevel Typelevel Native](https://user-images.githubusercontent.com/5440389/233789990-b16dd369-62e9-4ae9-8940-5333096f7fbd.png)


## Platform Pages

I would like for these pages to:
- talk a bit about the support and capabilities on each platform
  - e.g. the native page should link to [Arman's blog post](https://typelevel.org/blog/2022/09/19/typelevel-native.html)
  - e.g. the js page should briefly discuss the JS environment options: browser, severless, cli
-  list the projects that are supported by each platform

I want to be slightly more than just another project breakout list.
However, that might be achieved over multiple PRs so we can divide up the yak shaving.

## Tags

This PR also removes the `category` tag in favour of the `platforms` tag.
I am hoping this isn't too controversial.
I do not think the `category` tag is useful in its current form, a possibly more useful tag might pull in the GitHub topics, but that is out of scope here. The category tag is also not universally used, and it almost requires a bit of moderation. Whereas the `platform` tag is a lot more factual.