### PR TITLE
Updates to projects.yml

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -125,11 +125,10 @@
   github: "https://github.com/typelevel/keypool"
 - title: "kind-projector"
   description: "Plugin for nicer type-lambda syntax"
-  github: "https://github.com/non/kind-projector"
+  github: "https://github.com/typelevel/kind-projector"
 - title: "Kittens"
   description: "Automatic type class derivation"
-  github: "https://github.com/milessabin/kittens"
-  affiliate: true
+  github: "https://github.com/typelevel/kittens"
 - title: "Libra"
   description: "Compile time dimensional analysis for any problem domain"
   github: "https://github.com/to-ithaca/libra"
@@ -145,8 +144,8 @@
   affiliate: true
 - title: "Monocle"
   category: "Lenses for Scala"
-  description: "Strongly inspired by Haskell's lens library, Monocle is an Optics library where Optics gather the concepts of Lens, Traversal, Optional, Prism and Iso."
-  github: "https://github.com/julien-truffaut/Monocle"
+  description: "Optics library offering a simple yet powerful API to access and transform immutable data"
+  github: "https://github.com/optics-dev/Monocle"
   affiliate: true
 - title: "Mouse"
   description: "Enrichments to standard library classes to ease functional programming"
@@ -174,7 +173,7 @@
 - title: "ScalaCheck"
   category: "Property checking"
   description: "ScalaCheck is a library for automated property-based testing. It contains generators for randomized test data and combinators for properties."
-  github: "https://github.com/rickynils/scalacheck"
+  github: "https://github.com/typelevel/scalacheck"
   permalink: "http://scalacheck.org/"
 - title: "scalacheck-shapeless"
   description: "Automatic derivation for ScalaCheck"
@@ -205,8 +204,7 @@
   core: true
 - title: "simulacrum"
   description: "First-class syntax for type classes"
-  github: "https://github.com/mpilquist/simulacrum"
-  affiliate: true
+  github: "https://github.com/typelevel/simulacrum"
 - title: "Simulacrum Scalafix"
   description: "Simulacrum as Scalafix rules"
   github: "https://github.com/typelevel/simulacrum-scalafix"
@@ -227,13 +225,11 @@
 - title: "spire"
   category: "Numeric abstractions"
   description: "Spire is a numeric library for Scala which is intended to be generic, fast, and precise. Using features such as specialization, macros, type classes, and implicits, Spire works hard to defy conventional wisdom around performance and precision trade-offs."
-  github: "https://github.com/non/spire"
-  affiliate: true
+  github: "https://github.com/typelevel/spire"
   core: true
 - title: "Squants"
   description: "The Scala API for Quantities, Units of Measure and Dimensional Analysis"
-  github: "https://github.com/garyKeorkunian/squants"
-  affiliate: true
+  github: "https://github.com/typelevel/squants"
 - title: "TwoTails"
   description: "A compiler plugin adding support for mutual tail recursion"
   github: "https://github.com/wheaties/TwoTails"


### PR DESCRIPTION
Update:
- https://github.com/typelevel/kind-projector
- https://github.com/typelevel/kittens
- https://github.com/optics-dev/Monocle (including description)
- https://github.com/typelevel/scalacheck
- https://github.com/typelevel/simulacrum
- https://github.com/typelevel/spire
- https://github.com/typelevel/squants

Removing "affiliate" status where projects are now hosted by typelevel