### PR TITLE
Fix project submission link

### DIFF
--- a/_includes/_cta-projects.html
+++ b/_includes/_cta-projects.html
@@ -4,7 +4,7 @@
             <h2><span>{{site.data.cta.submittingTitle}}</span></h2>
             <p>{{site.data.cta.submittingDescription}}</p>
 
-            <a class="button button-secondary" href="https://github.com/typelevel/governance/issues/new">Open a ticket!</a>
+            <a class="button button-secondary" href="https://github.com/typelevel/governance/issues/new/choose">Open a ticket!</a>
         </div>
     </div>
 </section>

--- a/_includes/_cta-projects.html
+++ b/_includes/_cta-projects.html
@@ -4,7 +4,7 @@
             <h2><span>{{site.data.cta.submittingTitle}}</span></h2>
             <p>{{site.data.cta.submittingDescription}}</p>
 
-            <a class="button button-secondary" href="https://github.com/typelevel/governance/issues/new?labels=projects&title=Project+submission:+">Open a ticket!</a>
+            <a class="button button-secondary" href="https://github.com/typelevel/governance/issues/new">Open a ticket!</a>
         </div>
     </div>
 </section>


### PR DESCRIPTION
The current link is bypassing the template. This more generic link takes you to the issue-template-picker and is unlikely to go stale.