### PR TITLE
Setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
This will keep the actions up-to-date, which would have prevented the current CI failures. 