### PR TITLE
Fix "core projects" listing on homepage

### DIFF
--- a/_includes/_section-projects.html
+++ b/_includes/_section-projects.html
@@ -5,7 +5,7 @@
       <p>{{site.data.description.projectsDescription}}</p>
     </div>
     <div class="projects-list">
-      {% assign projects = site.projects | where:'core', true %}
+      {% assign projects = site.data.projects | where:'core', true %}
       {% for project in projects limit:3 %}
       <a href="{{ project.github }}" class="project-item">
         <div class="project-item-content">


### PR DESCRIPTION
This restores the core project listing on the homepage which unfortunately broke back in https://github.com/typelevel/typelevel.github.com/pull/418

<img width="1153" alt="Screen Shot 2023-04-22 at 9 35 02 AM" src="https://user-images.githubusercontent.com/5440389/233788194-6cc6acfe-913b-4ee9-89af-d1fa8e97630d.png">
