### PR TITLE
Add projects support all platforms to platform index page

### DIFF
--- a/_data/filter-platforms.yml
+++ b/_data/filter-platforms.yml
@@ -1,3 +1,6 @@
+- title: All
+  url: /platforms/
+  category: all
 - title: JS
   url: /platforms/js/
   category: js

--- a/platforms/index.html
+++ b/platforms/index.html
@@ -7,6 +7,7 @@ title: Platforms
     <div class="masthead-page">
       <h1><span>{{ page.title }}</span></h1>
       <p>Check out the Typelevel ecosystem by platform</p>
+      <p>Below are projects supporting all platforms: JS, JVM, and Native</p>
       {% include _tab-platforms.html %}
     </div>
 

--- a/platforms/index.html
+++ b/platforms/index.html
@@ -9,5 +9,24 @@ title: Platforms
       <p>Check out the Typelevel ecosystem by platform</p>
       {% include _tab-platforms.html %}
     </div>
+
+    {% assign allPlatforms = "js, jvm, native" | split: ", " %}
+    <div class="projects-list">
+      {% for project in site.data.projects %}
+      {% if project.platforms == allPlatforms %}
+      <a href="{{ project.github }}" class="project-item">
+        <div class="project-item-content">
+          <div>
+            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
+            <h3>{{ project.title }}</h3>
+          </div>
+          <p>{{ project.description }}</p>
+        </div>
+        {% include _project_platforms_tag.html %}
+        {% include _project_membership.html %}
+      </a>
+      {% endif %}
+      {% endfor %}
+    </div>
   </div>
 </div>


### PR DESCRIPTION
<img width="1027" alt="Screen Shot 2023-04-24 at 8 20 33 PM" src="https://user-images.githubusercontent.com/5440389/234143488-2101fb57-1a90-40da-a176-01017bf61e63.png">

Currently the project listing is the same as that of the native platform page, but that might not be the case for long.
