### PR TITLE
Add project card include

### DIFF
--- a/_includes/_project_card.html
+++ b/_includes/_project_card.html
@@ -6,6 +6,14 @@
     </div>
     <p>{{ project.description }}</p>
   </div>
-  {% include _project_platforms_tag.html %}
-  {% include _project_membership.html %}
+  <div class="project-item-tag">
+    <p>{{ project.platforms | join: " / "}}</p>
+  </div>
+  <div class="project-membership">
+    {% if project.affiliate %}
+    <img src="https://img.shields.io/badge/typelevel-affiliate%20project-FFB4B5.svg" alt="Typelevel Affiliate Project" />
+    {% else %}
+    <img src="https://img.shields.io/badge/typelevel-organization%20project-FF6169.svg" alt="Typelevel Organization Project" />
+    {% endif %}
+  </div>
 </a>

--- a/_includes/_project_card.html
+++ b/_includes/_project_card.html
@@ -1,0 +1,11 @@
+<a href="{{ project.github }}" class="project-item">
+  <div class="project-item-content">
+    <div>
+      <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
+      <h3>{{ project.title }}</h3>
+    </div>
+    <p>{{ project.description }}</p>
+  </div>
+  {% include _project_platforms_tag.html %}
+  {% include _project_membership.html %}
+</a>

--- a/_includes/_project_membership.html
+++ b/_includes/_project_membership.html
@@ -1,7 +1,0 @@
-<div class="project-membership">
-  {% if project.affiliate %}
-  <img src="https://img.shields.io/badge/typelevel-affiliate%20project-FFB4B5.svg" alt="Typelevel Affiliate Project" />
-  {% else %}
-  <img src="https://img.shields.io/badge/typelevel-organization%20project-FF6169.svg" alt="Typelevel Organization Project" />
-  {% endif %}
-</div>

--- a/_includes/_project_platforms_tag.html
+++ b/_includes/_project_platforms_tag.html
@@ -1,3 +1,0 @@
-<div class="project-item-tag">
-  <p>{{ project.platforms | join: " / "}}</p>
-</div>

--- a/_includes/_section-projects.html
+++ b/_includes/_section-projects.html
@@ -7,17 +7,7 @@
     <div class="projects-list">
       {% assign projects = site.data.projects | where:'core', true %}
       {% for project in projects limit:3 %}
-      <a href="{{ project.github }}" class="project-item">
-        <div class="project-item-content">
-          <div>
-            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
-            <h3>{{ project.title }}</h3>
-          </div>
-          <p>{{ project.description }}</p>
-        </div>
-        {% include _project_platforms_tag.html %}
-        {% include _project_membership.html %}
-      </a>
+        {% include _project_card %}
       {% endfor %}
     </div>
     <div class="section-cta">

--- a/_includes/_section-projects.html
+++ b/_includes/_section-projects.html
@@ -7,7 +7,7 @@
     <div class="projects-list">
       {% assign projects = site.data.projects | where:'core', true %}
       {% for project in projects limit:3 %}
-        {% include _project_card %}
+        {% include _project_card.html %}
       {% endfor %}
     </div>
     <div class="section-cta">

--- a/platforms/index.html
+++ b/platforms/index.html
@@ -14,19 +14,9 @@ title: Platforms
     {% assign allPlatforms = "js, jvm, native" | split: ", " %}
     <div class="projects-list">
       {% for project in site.data.projects %}
-      {% if project.platforms == allPlatforms %}
-      <a href="{{ project.github }}" class="project-item">
-        <div class="project-item-content">
-          <div>
-            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
-            <h3>{{ project.title }}</h3>
-          </div>
-          <p>{{ project.description }}</p>
-        </div>
-        {% include _project_platforms_tag.html %}
-        {% include _project_membership.html %}
-      </a>
-      {% endif %}
+        {% if project.platforms == allPlatforms %}
+          {% include _project_card %}
+        {% endif %}
       {% endfor %}
     </div>
   </div>

--- a/platforms/index.html
+++ b/platforms/index.html
@@ -15,7 +15,7 @@ title: Platforms
     <div class="projects-list">
       {% for project in site.data.projects %}
         {% if project.platforms == allPlatforms %}
-          {% include _project_card %}
+          {% include _project_card.html %}
         {% endif %}
       {% endfor %}
     </div>

--- a/platforms/js.html
+++ b/platforms/js.html
@@ -19,19 +19,9 @@ permalink: /platforms/js/
 
     <div class="projects-list">
       {% for project in site.data.projects %}
-      {% if project.platforms contains "js" %}
-      <a href="{{ project.github }}" class="project-item">
-        <div class="project-item-content">
-          <div>
-            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
-            <h3>{{ project.title }}</h3>
-          </div>
-          <p>{{ project.description }}</p>
-        </div>
-        {% include _project_platforms_tag.html %}
-        {% include _project_membership.html %}
-      </a>
-      {% endif %}
+        {% if project.platforms contains "js" %}
+          {% include _project_card %}
+        {% endif %}
       {% endfor %}
     </div>
   </div>

--- a/platforms/js.html
+++ b/platforms/js.html
@@ -20,7 +20,7 @@ permalink: /platforms/js/
     <div class="projects-list">
       {% for project in site.data.projects %}
         {% if project.platforms contains "js" %}
-          {% include _project_card %}
+          {% include _project_card.html %}
         {% endif %}
       {% endfor %}
     </div>

--- a/platforms/jvm.html
+++ b/platforms/jvm.html
@@ -20,7 +20,7 @@ permalink: /platforms/jvm/
     <div class="projects-list">
       {% for project in site.data.projects %}
         {% if project.platforms contains "jvm" %}
-          {% include _project_card %}
+          {% include _project_card.html %}
         {% endif %}
       {% endfor %}
     </div>

--- a/platforms/jvm.html
+++ b/platforms/jvm.html
@@ -19,19 +19,9 @@ permalink: /platforms/jvm/
 
     <div class="projects-list">
       {% for project in site.data.projects %}
-      {% if project.platforms contains "jvm" %}
-      <a href="{{ project.github }}" class="project-item">
-        <div class="project-item-content">
-          <div>
-            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
-            <h3>{{ project.title }}</h3>
-          </div>
-          <p>{{ project.description }}</p>
-        </div>
-        {% include _project_platforms_tag.html %}
-        {% include _project_membership.html %}
-      </a>
-      {% endif %}
+        {% if project.platforms contains "jvm" %}
+          {% include _project_card %}
+        {% endif %}
       {% endfor %}
     </div>
   </div>

--- a/platforms/native.html
+++ b/platforms/native.html
@@ -20,7 +20,7 @@ permalink: /platforms/native/
     <div class="projects-list">
       {% for project in site.data.projects %}
         {% if project.platforms contains "native" %}
-          {% include _project_card %}
+          {% include _project_card.html %}
         {% endif %}
       {% endfor %}
     </div>

--- a/platforms/native.html
+++ b/platforms/native.html
@@ -19,19 +19,9 @@ permalink: /platforms/native/
 
     <div class="projects-list">
       {% for project in site.data.projects %}
-      {% if project.platforms contains "native" %}
-      <a href="{{ project.github }}" class="project-item">
-        <div class="project-item-content">
-          <div>
-            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
-            <h3>{{ project.title }}</h3>
-          </div>
-          <p>{{ project.description }}</p>
-        </div>
-        {% include _project_platforms_tag.html %}
-        {% include _project_membership.html %}
-      </a>
-      {% endif %}
+        {% if project.platforms contains "native" %}
+          {% include _project_card %}
+        {% endif %}
       {% endfor %}
     </div>
   </div>

--- a/projects/affiliate.html
+++ b/projects/affiliate.html
@@ -14,19 +14,9 @@ permalink: /projects/affiliate/
 
     <div class="projects-list">
       {% for project in site.data.projects %}
-      {% if project.affiliate %}
-      <a href="{{ project.github }}" class="project-item">
-        <div class="project-item-content">
-          <div>
-            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
-            <h3>{{ project.title }}</h3>
-          </div>
-          <p>{{ project.description }}</p>
-        </div>
-        {% include _project_platforms_tag.html %}
-        {% include _project_membership.html %}
-      </a>
-      {% endif %}
+        {% if project.affiliate %}
+          {% include _project_card %}
+        {% endif %}
       {% endfor %}
     </div>
   </div>

--- a/projects/affiliate.html
+++ b/projects/affiliate.html
@@ -15,7 +15,7 @@ permalink: /projects/affiliate/
     <div class="projects-list">
       {% for project in site.data.projects %}
         {% if project.affiliate %}
-          {% include _project_card %}
+          {% include _project_card.html %}
         {% endif %}
       {% endfor %}
     </div>

--- a/projects/index.html
+++ b/projects/index.html
@@ -11,7 +11,7 @@ title: Projects
     </div>
     <div class="projects-list">
       {% for project in site.data.projects %}
-        {% include _project_card %}
+        {% include _project_card.html %}
       {% endfor %}
     </div>
   </div>

--- a/projects/index.html
+++ b/projects/index.html
@@ -11,17 +11,7 @@ title: Projects
     </div>
     <div class="projects-list">
       {% for project in site.data.projects %}
-      <a href="{{ project.github }}" class="project-item">
-        <div class="project-item-content">
-          <div>
-            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
-            <h3>{{ project.title }}</h3>
-          </div>
-          <p>{{ project.description }}</p>
-        </div>
-        {% include _project_platforms_tag.html %}
-        {% include _project_membership.html %}
-      </a>
+        {% include _project_card %}
       {% endfor %}
     </div>
   </div>

--- a/projects/organization.html
+++ b/projects/organization.html
@@ -14,19 +14,9 @@ permalink: /projects/organization/
 
     <div class="projects-list">
       {% for project in site.data.projects %}
-      {% if project.affiliate != true %}
-      <a href="{{ project.github }}" class="project-item">
-        <div class="project-item-content">
-          <div>
-            <img src="{{ site.baseurl }}/img/assets/icon-project.svg" alt="">
-            <h3>{{ project.title }}</h3>
-          </div>
-          <p>{{ project.description }}</p>
-        </div>
-        {% include _project_platforms_tag.html %}
-        {% include _project_membership.html %}
-      </a>
-      {% endif %}
+        {% if project.affiliate != true %}
+          {% include _project_card %}
+        {% endif %}
       {% endfor %}
     </div>
   </div>

--- a/projects/organization.html
+++ b/projects/organization.html
@@ -15,7 +15,7 @@ permalink: /projects/organization/
     <div class="projects-list">
       {% for project in site.data.projects %}
         {% if project.affiliate != true %}
-          {% include _project_card %}
+          {% include _project_card.html %}
         {% endif %}
       {% endfor %}
     </div>


### PR DESCRIPTION
Builds on https://github.com/typelevel/typelevel.github.com/pull/445
No user facing changes.

Reduces some duplication by having a single project card include and leveraging that everywhere.
Additionally, reduces some indirection and inlines the project membership and platforms in that project card include.