### PR TITLE
Fix syntax highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,8 @@ sass:
 
 permalink: pretty
 
+highlighter: none
+
 # Serving, url
 # ---------------------------------------------------------------
 baseurl: "/typelevel.github.com"

--- a/_includes/_js-bottom.html
+++ b/_includes/_js-bottom.html
@@ -1,4 +1,5 @@
 <script type="text/javascript" src="{{ '/js/functions.js' | relative_url }}"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/languages/scala.min.js"></script>
 <script>hljs.highlightAll();</script>
 <script src="https://kit.fontawesome.com/a7055d991d.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
This fixes syntax highlighting for the site.

Currently Scala code looks like this (https://typelevel.org/blog/2018/11/28/http4s-error-handling-mtl-2.html)
<img width="738" alt="Screenshot 2023-06-22 at 8 34 20 PM" src="https://github.com/typelevel/typelevel.github.com/assets/6521018/57bb43e4-ef41-4af2-bfea-d0071c4714a2">

This is how it looks after the fix
<img width="742" alt="Screenshot 2023-06-22 at 8 35 15 PM" src="https://github.com/typelevel/typelevel.github.com/assets/6521018/b7dca982-74d2-4fb6-918c-1c205f844f94">