### PR TITLE
Fix syntax highlighting for github pages (cont)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,10 @@ url: ""
 # ---------------------------------------------------------------
 markdown: kramdown
 
+kramdown:
+  syntax_highlighter_opts:
+    disable: true
+
 # Handling Reading
 # ---------------------------------------------------------------
 exclude:


### PR DESCRIPTION
After #454, looks like the live site still has the default jekyll syntax highlighter enabled, conflicting with highlight.js. (Inspecting element on any piece of code on the site will show both `highlighter-rouge` and `hljs...`)

This is due to github-pages using a different version of jekyll (3.9.3) than the one defined in Gemfile. This fix actually fixes that for the live site.

See https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#syntax-highlighting.