### PR TITLE
Specify github repo url for calico

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -10,7 +10,8 @@
   platforms: [js, jvm]
 - title: "calico"
   description: "Pure, reactive UI library for building web applications with Cats Effect + FS2"
-  github: "https://armanbilge.github.io/calico"
+  github: "https://github.com/armanbilge/calico"
+  permalink: "https://armanbilge.github.io/calico"
   affiliate: true
   platforms: [js]
 - title: "case-insensitive"


### PR DESCRIPTION
The `github` link is supposed to be the link to the repo.
`permalink` can link to the project page / documentation.