### PR TITLE
Add JSON list of projects at 'projects/all.json'

### DIFF
--- a/projects/all.json.html
+++ b/projects/all.json.html
@@ -1,0 +1,5 @@
+---
+title: All Projects
+permalink: /projects/all.json
+---
+{{ site.data.projects | jsonify }}


### PR DESCRIPTION
This PR adds a new endpoint `https://typelevel.org/projects/all.json` that responds with a JSON list of all the Typelevel projects data.
It leverages the existing `_data/projects.yml` data and a `jsonify` liquid filter, so the data will always be in sync with the project listing pages.

The goal is to enable some cheap and cheerful programmatic access to the projects data.

## Testing

I ran locally via `tl-preview` and browsed to http://127.0.0.1:4000/projects/all.json, firefox nicely renders the JSON

![Screenshot 2023-07-17 at 08-26-36 Screenshot](https://github.com/typelevel/typelevel.github.com/assets/5440389/e1b34b12-1c57-4fb5-ba68-6eb5f7f3ddb8)

![Screenshot 2023-07-17 at 08-24-13 Screenshot](https://github.com/typelevel/typelevel.github.com/assets/5440389/2a67bc40-942d-40d3-b028-ed62b05f0372)

Additionally one can curl and pipe into `jq` like so:

`curl http://127.0.0.1:4000/projects/all.json | jq '.'`
```json
[
  {
    "title": "argonaut-shapeless",
    "description": "Automatic derivation for argonaut",
    "github": "https://github.com/alexarchambault/argonaut-shapeless",
    "affiliate": true,
    "platforms": [
      "jvm"
    ]
  },
```