### PR TITLE
Fix NE Scala URL

### DIFF
--- a/collections/_events/2023-10-26-summit-nescala.md
+++ b/collections/_events/2023-10-26-summit-nescala.md
@@ -15,7 +15,7 @@ sponsors_section: false
 
 ## About the Summit
 
-The tenth Typelevel Summit will once again be co-hosted with the [Northeast Scala Symposium](http://www.nescala.org/) virtually, with one of day of talks and one day of unconference, accompanied by discussion and socializing online throughout.
+The tenth Typelevel Summit will once again be co-hosted with the [Northeast Scala Symposium](https://nescalas.github.io/) virtually, with one of day of talks and one day of unconference, accompanied by discussion and socializing online throughout.
 
 The schedule for this year is as follows:
 


### PR DESCRIPTION
The content is currently pointing to an illegal version of the URL.  Maybe the publication problem is that the Markdown generator is silently checking URLs, and this is getting a 404?  Let's try changing to a known-good that doesn't involve any redirection, and see if that fixes it.