### PR TITLE
Update site description with mission statement

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # ---------------------------------------------------------------
 name: Typelevel
 title: Typelevel
-description: Let the Scala compiler work for you. We provide type classes, instances, conversions, testing, supplements to the standard library, and much more.
+description: Typelevel is an association of projects and individuals united to foster an inclusive, welcoming, and safe environment around functional programming in Scala.
 author: Israel Pérez
 keywords: theme, jekyll, unstyle
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # ---------------------------------------------------------------
 name: Typelevel
 title: Typelevel
-description: Typelevel is an ecosystem of projects and community of people united to foster an inclusive, welcoming, and safe environment around functional programming in Scala.
+description: Typelevel is an ecosystem of projects and a community of people united to foster an inclusive, welcoming, and safe environment around functional programming in Scala.
 author: Israel Pérez
 keywords: theme, jekyll, unstyle
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # ---------------------------------------------------------------
 name: Typelevel
 title: Typelevel
-description: Typelevel is an association of projects and individuals united to foster an inclusive, welcoming, and safe environment around functional programming in Scala.
+description: Typelevel is an ecosystem of projects and community of people united to foster an inclusive, welcoming, and safe environment around functional programming in Scala.
 author: Israel Pérez
 keywords: theme, jekyll, unstyle
 


### PR DESCRIPTION
The mission statement taken from:
https://typelevel.org/blog/2022/04/01/call-for-steering-committee-members.html

![image](https://github.com/typelevel/typelevel.github.com/assets/5440389/4a0f4603-494c-4889-b175-f789846f443a)

