### PR TITLE
Add cats-stm to projects

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -53,6 +53,11 @@
   github: "https://github.com/IronCoreLabs/cats-scalatest"
   affiliate: true
   platforms: [js, jvm]
+- title: "cats-stm"
+  description: "A STM implementation for Cats Effect"
+  github: "https://github.com/TimWSpence/cats-stm"
+  affiliate: true
+  platforms: [js, jvm, native]
 - title: "Cats Tagless"
   description: "A library of utilities for tagless final algebras"
   github: "https://github.com/typelevel/cats-tagless/"


### PR DESCRIPTION
Adding cats-stm as an affiliate project as per https://github.com/typelevel/governance/issues/119

cc. @TimWSpence