### PR TITLE
Remove `affiliate` from a few org projects

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -315,7 +315,6 @@
 - title: "simulacrum"
   description: "First-class syntax for type classes"
   github: "https://github.com/typelevel/simulacrum"
-  affiliate: true
   platforms: [js, jvm, native]
 - title: "Simulacrum Scalafix"
   description: "Simulacrum as Scalafix rules"

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -348,7 +348,6 @@
 - title: "Squants"
   description: "The Scala API for Quantities, Units of Measure and Dimensional Analysis"
   github: "https://github.com/typelevel/squants"
-  affiliate: true
   platforms: [js, jvm, native]
 - title: "TwoTails"
   description: "A compiler plugin adding support for mutual tail recursion"

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -208,7 +208,6 @@
 - title: "Kittens"
   description: "Automatic type class derivation"
   github: "https://github.com/typelevel/kittens"
-  affiliate: true
   platforms: [js, jvm, native]
 - title: "Laika"
   description: "Site and e-book generator and customizable text markup transformer for sbt, Scala and Scala.js"


### PR DESCRIPTION
Some of this was originally done in https://github.com/typelevel/typelevel.github.com/pull/424
But I think I messed things up in the big one file squish.
Oh well, I've gone through all the affiliate projects now and I think this is it.