### PR TITLE
Add blog post on GH seat limit

### DIFF
--- a/collections/_posts/2024-02-24-github-seats.md
+++ b/collections/_posts/2024-02-24-github-seats.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: GitHub Seats
+category: technical
+
+meta:
+  nav: blog
+  author: valencik
+---
+
+As we continue to grow our community on GitHub, we've encountered a challenge with our seat limit for maintainers.
+It's important to note that each maintainer seat incurs a fee.
+By managing our maintainers more efficiently, we can allocate resources effectively and sustain the growth of our community.
+
+In order to be able to add new members, we've recently conducted a review and removed 25 accounts that have not been active on the organization since January 1st, 2023.
+
+We understand that circumstances may vary, and if you believe your account was removed in error, we want to hear from you!
+Please don't hesitate to reach out to us, and we'll happily re-add you as a maintainer.


### PR DESCRIPTION
Adds a small post detailing the removal of 25 maintainers.

Users were identified by checking each member of the Typelevel org from https://github.com/orgs/typelevel/people
And looking to see if they had any commit, issue, or PR activity since 2023-01-01 with a GH search like the following:

https://github.com/search?q=author%3Avalencik+org%3Atypelevel+author-date%3A%3E2023-01-01&type=commits&s=author-date&o=asc

**DO NOT MERGE**
The removal has not actually happened yet, we've just identified the users.
Hoping to do the removal tomorrow.
Please review the content here anyways though.
:)
**DO NOT MERGE**