### PR TITLE
update discord link

### DIFF
--- a/collections/_posts/2021-05-05-discord-migration.md
+++ b/collections/_posts/2021-05-05-discord-migration.md
@@ -31,4 +31,4 @@ and we also hope that other tools like Github Discussions and FAQ's/project docs
 
 We encourage Typelevel projects to create channels there and to give it a try for a few months and see how it goes.
 
-### [We hope you'll join us over on the new Discord - https://discord.gg/XF3CXcMzqD](https://discord.gg/XF3CXcMzqD)
+### [We hope you'll join us over on the new Discord - https://discord.gg/dXWPjcKv2A](https://discord.gg/dXWPjcKv2A)


### PR DESCRIPTION
The discord announcement blog post has a discord invite link in it. It was reported in `#admin` (back at the start of April, sorry for the delay!) that someone had tried to use this link and it's apparently expired. Since it sounds like people still try to join the discord via this link, I'm updating it :) 