### PR TITLE
Change the projects listed on the homepage

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -30,7 +30,6 @@
   description: "A library intended to provide abstractions for functional programming in Scala, leveraging its unique features. Design goals are approachability, modularity, documentation and efficiency."
   permalink: "https://typelevel.org/cats/"
   github: "https://github.com/typelevel/cats"
-  core: true
   platforms: [js, jvm, native]
 - title: "Cats Collections"
   description: "Data structures that facilitate pure functional programming with cats"
@@ -314,7 +313,6 @@
   description: "Shapeless is a generic programming library. Starting with implementations of Scrap your boilerplate and higher rank polymorphism in Scala, it quickly grew to provide advanced abstract tools like heterogenous lists and automatic instance derivation for type classes."
   github: "https://github.com/milessabin/shapeless"
   affiliate: true
-  core: true
   platforms: [js, jvm, native]
 - title: "simulacrum"
   description: "First-class syntax for type classes"
@@ -347,7 +345,6 @@
 - title: "spire"
   description: "Spire is a numeric library for Scala which is intended to be generic, fast, and precise. Using features such as specialization, macros, type classes, and implicits, Spire works hard to defy conventional wisdom around performance and precision trade-offs."
   github: "https://github.com/typelevel/spire"
-  core: true
   platforms: [js, jvm, native]
 - title: "Squants"
   description: "The Scala API for Quantities, Units of Measure and Dimensional Analysis"

--- a/_includes/_section-projects.html
+++ b/_includes/_section-projects.html
@@ -4,9 +4,10 @@
       <h2><span>{{site.data.description.projectsTitle}}</span></h2>
       <p>{{site.data.description.projectsDescription}}</p>
     </div>
-    <div class="projects-list">
-      {% assign projects = site.data.projects | where:'core', true %}
-      {% for project in projects limit:3 %}
+    <div id="homeProjects" class="projects-list">
+      {% assign names = "Cats|Cats-Effect|fs2|http4s" | split: "|" %}
+      {% assign projects = site.data.projects | where_exp: "project", "names contains project.title" %}
+      {% for project in projects %}
         {% include _project_card.html %}
       {% endfor %}
     </div>

--- a/_sass/components/_projects.scss
+++ b/_sass/components/_projects.scss
@@ -3,6 +3,9 @@
 // =====================================================================
 
 #section-projects {}
+#homeProjects {
+  @include col-2;
+}
 .projects-list {
   @include grid;
   @include col-3;


### PR DESCRIPTION
@valencik nerd-sniped me, this PR it's the outcome.

If we want to change the listed projects it's enough to pick different ones in the `names` array
```
{% assign names = "Cats|Cats-Effect|fs2|http4s" | split: "|" %}
```
The values must correspond to titles in the [projects data](https://github.com/typelevel/typelevel.github.com/blob/main/_data/projects.yml)

I'll say that either four or six projects is the perfect number to show on the home