### PR TITLE
GSoC 2025 refresh

### DIFF
--- a/_data/gsoc-ideas.yml
+++ b/_data/gsoc-ideas.yml
@@ -15,53 +15,19 @@
   mentors: [armanbilge, djspiewak, ekrich, valencik]
   categories: [AI, web, programming languages]
 
-- title: "Streaming msgpack implementation"
-  description: "The [msgpack](https://msgpack.org/) data format allows for efficient binary serialization of data. It would be great to have the ability to parse, transform, and emit data in a streaming fashion using FS2 in the [fs2-data](https://fs2-data.gnieh.org) library."
-  prereqs: Scala, ideally some experience with FS2 and parsing
-  difficulty: Medium. 
-  length: medium
-  mentors: [satabin, ybasket]
-  categories: [streaming, programming languages]
-
-- title: Scaladoc Search in Protosearch
-  description:
-    Protosearch offers an in-browser search experience for documentation. This project aims to add support for Scaladoc, the documentation system for Scala code. As a result of this work, searching for `flatMap` on the cats-effect documentation, for example, would return hits from the tutorial and the relevant method in the Scaladoc.
-  prereqs: Scala
-  difficulty: Medium.
-  length: long
-  mentors: [valencik]
-  categories: [data, web]
-
-- title: Fluent library for files and processes
-  description:
-    FS2 has powerful APIs for streaming I/O but using it in small scripts can involve boilerplate. This project aims to create a fluent library for working with files and processes in Scala. A particular focus will be easy integration with the [Typelevel Toolkit](https://typelevel.org/toolkit).
-  prereqs: Scala, interest in Functional Programming
-  difficulty: Medium.
-  length: medium
-  mentors: [toniogela, zetashift, lenguyenthanh]
-  categories: [programming languages]
-
 - title: Serverless integrations for Feral
   description:
-    Feral is a Typelevel library for building serverless functions that currently supports AWS Lambda. We want to support other cloud providers, such as Google, Cloudflare, and Vercel.
+    Feral is a Typelevel library for building serverless functions that currently supports AWS Lambda and Google Cloud Run Functions. We want to support more cloud providers, such as Cloudflare Workers.
   prereqs: Scala, interest in Functional Programming, ideally experience with serverless
   difficulty: Medium.
   length: medium
-  mentors: [armanbilge, toniogela]
+  mentors: [armanbilge]
   categories: [cloud, programming languages]
 
 - title: Native I/O backend for FS2 JVM
   description:
     FS2 on the JVM currently implements its networking API using JDK NIO. Unfortunately this indirection incurs a non-trivial performance penalty. We want to replace the use of JDK NIO with direct calls to system I/O APIs such as `epoll` and `kqueue`.
   prereqs: Scala, ability to read C
-  difficulty: Medium.
-  length: long
-  mentors: [antoniojimeneznieto, djspiewak, armanbilge]
-  categories: [operating systems, programming languages]
-
-- title: Production-ready io_uring interop layer
-  description: A GSoC 2023 project prototyped a new networking I/O layer for FS2 based on the Linux io_uring syscall interface that improved the performance of HTTP servers by more than 3x. Now we need help to make this production-ready by writing code to interoperate with io_uring from the JVM.
-  prereqs: Java or Scala, ideally some experience with C and JNI
   difficulty: Medium.
   length: long
   mentors: [antoniojimeneznieto, djspiewak, armanbilge]

--- a/_data/gsoc-projects.yml
+++ b/_data/gsoc-projects.yml
@@ -1,12 +1,24 @@
-- title: "UringSystem using io_uring"
-  description: "Integrated Cats Effect and FS2 with Linux kernel APIs and made Ember 3x faster!"
+- title: "I/O polling with io_uring"
+  description: "Integrated Cats Effect and FS2 with Linux kernel APIs, making http4s Ember benchmark 3x faster!"
   permalink: "https://github.com/armanbilge/fs2-io_uring/pull/78"
   categories: [operating systems]
 - title: "Ember Web Sockets"
-  description: "Implemented network protocols and enabled more projects to cross-compile and run on 100% Typelevel stack"
+  description: "Implemented the Websocket network protocol in http4s Ember, unblocking JS/Native support for a Kubernetes client."
   permalink: "https://github.com/http4s/http4s/pull/7261"
   categories: [web]
 - title: "Pure Scala Open Telemetry APIs"
-  description: "Designed Scala APIs for Open Telemetry Specifications and opened the door to a pure Scala SDK"
+  description: "Designed Scala APIs for Open Telemetry Specifications and opened the door to a pure Scala SDK."
   permalink: "https://github.com/typelevel/otel4s/pull/236"
   categories: [tracing]
+- title: "Going Feral on the Cloud"
+  description: "Introduced a Google Cloud Run Functions integration for Feral to deploy http4s apps in Google's serverless platform."
+  permalink: "/blog/2024/12/22/gsoc24-going-feral-on-the-cloud.html"
+  categories: [cloud, programming languages]
+- title: "Catscript"
+  description: "Designed a new library for easy scripting with files and processes, for inclusion in the Typelevel Toolkit."
+  permalink: "https://github.com/typelevel/governance/issues/149"
+  categories: [programming languages]
+- title: "Scaladoc search in Protosearch"
+  description: "Integrated Prosoearchwith Scaladocs, enabling a unified search experience across a project's written and API docs."
+  permalink: "https://github.com/cozydev-pink/protosearch/pull/241"
+  categories: [data, web]

--- a/_includes/_gsoc_project_card.html
+++ b/_includes/_gsoc_project_card.html
@@ -1,4 +1,4 @@
-<a href="{{ project.github }}" class="gsoc-item">
+<a href="{{ project.permalink }}" class="gsoc-item">
   <div class="gsoc-item-content">
     <div>
       <img src="{{ site.baseurl }}/img/assets/icon-about-modular.svg" alt="">

--- a/gsoc/index.html
+++ b/gsoc/index.html
@@ -6,24 +6,25 @@ title: "GSoC: Guidance"
   <div class="container container-blog">
     <div class="masthead-blog-detal">
       <h1><span>{{ page.title }}</span></h1>
-      <p>Some guidelines on joining and working with Typelevel for the GSoC.</p>
+      <p>Some guidelines on joining and working with Typelevel for GSoC.</p>
       {% include _tab-gsoc.html %}
     </div>
     <div class="blog-detail-content">
       <h2>Welcome!</h2>
       <p>
-        Typelevel will be participating in GSoC 2024 under the auspices of the <a href="https://scala.epfl.ch/">Scala Center</a>.
-        Please read the Center's <a href="https://github.com/scalacenter/GoogleSummerOfCode?tab=readme-ov-file#rules">rules</a> for contributors.
+        Typelevel is in the process of applying to be a mentoring organization for
+        <a href="https://summerofcode.withgoogle.com/">Google Summer of Code 2025</a>.
+        Stay tuned!
       </p>
       <p>
         Contributors: Feel free to join our Discord server and introduce yourself in the
         <a href="https://discord.gg/hAKabfGjUw">#summer-of-code channel</a>.
-        We can help you get started with contributing to our projects and help you find a mentor.
+        We are still early in the GSoC process, but we would love to say hello and help you get started with contributing to our projects!
       </p>
       <p>
         Mentors: Please reach out in the
-        <a href="https://github.com/orgs/typelevel/discussions/128">GitHub org discussion</a>
-        if you want to be part of GSoC 2024.
+        <a href="https://github.com/orgs/typelevel/discussions/156">GitHub org discussion</a>
+        if you want to be part of GSoC 2025.
       </p>
     </div>
   </div>

--- a/gsoc/past-projects.html
+++ b/gsoc/past-projects.html
@@ -8,7 +8,7 @@ permalink: /gsoc/projects/
   <div class="container">
     <div class="masthead-page">
       <h1><span>{{ page.title }}</span></h1>
-      <p>Checkout some of our projects from past GSoC years!</p>
+      <p>Checkout some of our projects from past GSoC years!</p><p>Click on a project card to learn more about it.</p>
       {% include _tab-gsoc.html %}
     </div>
 


### PR DESCRIPTION
(Begins) refreshing our materials for GSoC 2025.

1. Status update on landing page i.e. org application in-process.
2. Clear out completed projects from Ideas. (🎉 so many to remove!! 😮 )
3. Add last years' projects to Past Projects. (I only added the "official" GSoC projects, 🤷, esp. since Google itself may be looking at these pages to evaluate our application)