### PR TITLE
Create security.txt

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,17 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+Contact: mailto:security@typelevel.org
+Expires: 2026-02-19T02:39Z
+Encryption: openpgp4fpr:904c153733dbb0106915c0bd975be5bc29d92ca5
+Encryption: openpgp4fpr:1cae49948ee0a2d7154a2b62a335b107e9282548
+Preferred-Languages: en
+Canonical: https://typelevel.org/.well-known/security.txt
+Policy: https://github.com/typelevel/.github/blob/main/SECURITY.md
+-----BEGIN PGP SIGNATURE-----
+
+iIwEARYKADQWIQQUykrE/bANX4J6vAxZhkimXfZFBgUCZ7VK6BYcbm9yZXBseUB0
+eXBlbGV2ZWwub3JnAAoJEFmGSKZd9kUGRb0BAPhyXJCoTtFNGaxjjL+m7j/8ein2
+j4barWRaFQqbXfnnAP4oFYY4hRVOEzLPoU0CNPh0BT2sPUUp1lXwPjf7YS47CQ==
+=Ca5d
+-----END PGP SIGNATURE-----


### PR DESCRIPTION
Follows https://www.rfc-editor.org/rfc/rfc9116

The key is signed by the same PGP key that signs our artifacts and is published to our site, but the referenced encryption keys are mine and @armanbilge's, as they appear on the Typelevel security policy.  This distinction makes sense in my mind, because Arman and I don't typically sign artifacts for Typelevel, and the Typelevel bot shouldn't receive encrypted messages.

This is something that should be renewed every year.

/cc @typelevel/security 