### PR TITLE
Add Contributing page, revamp About page

### DIFF
--- a/_data/cta.yml
+++ b/_data/cta.yml
@@ -7,7 +7,7 @@ submittingDescription: Are you interested in submitting your library to the Type
 blogTitle: Contribute to the blog
 blogDescription:  If you want to share something about a library or Scala topics in general (e.g. type classes), case studies, examples, or other related content, please do not hesitate to contact us. 
 
-conductTitle: Scala Code of Conduct
+conductTitle: Typelevel Code of Conduct
 conductDescription: We are committed to providing a friendly, safe and welcoming environment for all, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, sexual identity and orientation, or other such characteristics.
 
 steeringTitle: Steering Committee

--- a/_data/filter-about.yml
+++ b/_data/filter-about.yml
@@ -1,0 +1,4 @@
+- title: Overview
+  url: /about/
+- title: Contributing
+  url: /about/contribute/

--- a/_data/filter-about.yml
+++ b/_data/filter-about.yml
@@ -1,4 +1,4 @@
 - title: Overview
   url: /about/
 - title: Contributing
-  url: /about/contribute/
+  url: /about/contributing/

--- a/_includes/_tab-about.html
+++ b/_includes/_tab-about.html
@@ -1,0 +1,5 @@
+<ul class="tab">
+    {% for tabItem in site.data.filter-about %}
+    <li><a href="{{ site.baseurl }}{{tabItem.url}}" {% if tabItem.url == page.url %} class="active" {% endif %}>{{tabItem.title}}</a></li>
+    {% endfor %}
+</ul>

--- a/about/contribute.html
+++ b/about/contribute.html
@@ -17,7 +17,7 @@ permalink: /about/contribute/
 
       <p>Maintaining an organization at the scale of Typelevel incurs costs.
       Through FOSS funding we can provide better support to maintainers, and make stronger guarantees to users, by paying for things like CI infrastructure or community support.</p>
-      <p>Any amount of support is always welcome, and we appreciate anyone who contributes to the Typelevel Open Collective.</p>
+      <p>Any amount of support is always welcome, and we appreciate anyone who contributes to the <a href=https://opencollective.com/typelevel>Typelevel Open Collective.</a></p>
 
       </br>
       <p>By funding Typelevel, you're helping us maintain our domains, infrastructure, services, and our community safety through training the Code of Conduct Committee.</p>

--- a/about/contribute.html
+++ b/about/contribute.html
@@ -36,7 +36,6 @@ permalink: /about/contribute/
 
 
     </div>
-      {% include _tab-gsoc.html %}
     </div>
 
   </div>

--- a/about/contribute.html
+++ b/about/contribute.html
@@ -1,0 +1,44 @@
+---
+layout: page
+title: "Contributing"
+permalink: /about/contribute/
+---
+
+<div id="section-page">
+  <div class="container container-blog">
+    <div class="masthead-blog-detail">
+      <h1><span>{{ page.title }}</span></h1>
+      <div class="blog-detail-content">
+      </br>
+      <p>Typelevel is an ecosystem of projects and a community of people united to foster an inclusive, welcoming, and safe environment around functional programming in Scala.</p>
+
+
+      <h2>Financial Contributions</h2>
+
+      <p>Maintaining an organization at the scale of Typelevel incurs costs.
+      Through FOSS funding we can provide better support to maintainers, and make stronger guarantees to users, by paying for things like CI infrastructure or community support.</p>
+      <p>Any amount of support is always welcome, and we appreciate anyone who contributes to the Typelevel Open Collective.</p>
+
+      </br>
+      <p>By funding Typelevel, you're helping us maintain our domains, infrastructure, services, and our community safety through training the Code of Conduct Committee.</p>
+
+
+      <h2>Other Ways To Contribute</h2>
+
+
+      <p>Companies can donate developer time by allowing developers to contribute to open source on company time, and actively encourage it by dedicating time and space for those efforts.</p>
+
+      <p>The community can help by just getting involved, in any way that feels comfortable!
+      A PR is always welcome, whether code changes or documentation improvements, and asking questions helps clarify behaviors for everyone.
+      Any participation is greatly valued!</p>
+
+      <p>If you are looking for a place to start with a technical contribution, consider dropping by the 'starting-contributing' channel on discord, or checking out our <a href=https://github.com/orgs/typelevel/projects/1/views/1>Good First Issues board</a>.</p>
+
+
+    </div>
+      {% include _tab-gsoc.html %}
+    </div>
+
+  </div>
+</div>
+

--- a/about/contributing.html
+++ b/about/contributing.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Contributing"
-permalink: /about/contribute/
+permalink: /about/contributing/
 ---
 
 <div id="section-page">

--- a/about/contributing.html
+++ b/about/contributing.html
@@ -32,7 +32,7 @@ permalink: /about/contributing/
       A PR is always welcome, whether code changes or documentation improvements, and asking questions helps clarify behaviors for everyone.
       Any participation is greatly valued!</p>
 
-      <p>If you are looking for a place to start with a technical contribution, consider dropping by the 'starting-contributing' channel on discord, or checking out our <a href=https://github.com/orgs/typelevel/projects/1/views/1>Good First Issues board</a>.</p>
+      <p>If you are looking for a place to start with a technical contribution, consider dropping by the '#starting-contributing' channel on discord, or checking out our <a href=https://github.com/orgs/typelevel/projects/1/views/1>Good First Issues board</a>.</p>
 
 
     </div>

--- a/about/index.html
+++ b/about/index.html
@@ -8,7 +8,6 @@ title: About
   <div class="container">
     <div class="masthead-page">
       <h1><span>{{ page.title }}</span></h1>
-      <p>{{site.data.description.aboutDescription}}</p>
       <ul class="masthead-social">
 
         {% for item in site.data.nav-social %}
@@ -19,6 +18,10 @@ title: About
         </li>
         {% endfor %}
       </ul>
+    </div>
+    <div class="masthead-blog-detal">
+      <p>{{site.data.description.aboutDescription}}</p>
+      {% include _tab-about.html %}
     </div>
 
     <div class="about-list">

--- a/about/index.html
+++ b/about/index.html
@@ -20,6 +20,11 @@ title: About
       </ul>
     </div>
     <div class="masthead-blog-detal">
+      <p>
+        Typelevel is a community working together since 2013 to foster an inclusive, welcoming, and safe environment around functional programming in Scala.
+        Our ecosystem of libraries is mature and widely adopted.
+      </p>
+      </br>
       <p>{{site.data.description.aboutDescription}}</p>
       {% include _tab-about.html %}
     </div>


### PR DESCRIPTION
This PR adds a section to the About page about how to contribute to Typelevel, with a main focus on financial contributions.

Special shout out to @samspills who had already written most of this contributing content previously. :heart: 

Closes https://github.com/typelevel/typelevel.github.com/issues/415


![Screenshot 2025-02-20 at 19-03-36 Typelevel About](https://github.com/user-attachments/assets/89979cdd-4677-4295-a6b9-3fca3f544425)
![Screenshot 2025-02-20 at 19-03-49 Typelevel Contributing](https://github.com/user-attachments/assets/d4f9a89e-11db-4e36-9e58-cde18309f7d3)

