### PR TITLE
Add CODEOWNERS for event posts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Announcing official Typelevel events requires explicit mod approval
+/collections/_events/ @typelevel/steering


### PR DESCRIPTION
This should perhaps be a more specific team than steering, but I think this works for now.
I think it would be ok if it was one review from anyone on steering or the CoC committee.
But we currently lack a GH team for the CoC committee.