### PR TITLE
Add Lausanne meetup to events page

### DIFF
--- a/collections/_events/2025-08-15-meetup-lausanne.md
+++ b/collections/_events/2025-08-15-meetup-lausanne.md
@@ -1,0 +1,35 @@
+---
+layout: event
+
+title: "Typelevel Meetup Lausanne"
+short_title: "Lausanne Meetup"
+date_string: "August 22, 2025"
+location: "École Polytechnique Fédérale de Lausanne"
+description: "Learn more about Typelevel at an in-person, community meetup"
+
+poster_hero: "/img/media/lausanne.jpg"
+poster_thumb: "/img/media/lausanne-thumb.jpg"
+
+sponsors_section: false
+---
+
+## About the Meetup
+
+Join the Typelevel community at an [in-person meetup][luma] on EPFL campus in Lausanne, organized by [Arman Bilge] and [Antonio Jimenez]. This meetup is open to (aspiring) Typelevel users and contributors and anyone curious to learn more about functional programming in Scala, no matter their prior experience.
+
+During this meetup you can expect:
+
+* chat/q&a about functional programming and Typelevel libraries
+* a small tutorial on [Cats Effect], [FS2], and [Calico]
+* a group activity building widgets with Calico
+* lunch
+
+More details and registration are available on the [event page][luma]. All participants and organizers must abide by the [Typelevel Code of Conduct].
+
+[Arman Bilge]: https://github.com/armanbilge
+[Antonio Jimenez]: https://github.com/antoniojimeneznieto
+[Typelevel Code of Conduct]: /code-of-conduct.html
+[Cats Effect]: /cats-effect
+[FS2]: https://fs2.io/
+[Calico]: https://armanbilge.github.io/calico
+[luma]: https://lu.ma/g7qow6h3


### PR DESCRIPTION
Listing the community meetup that @antoniojimeneznieto and I are organizing in Lausanne.

<details>
<img width="2146" height="1662" alt="4000-armanbilge-typelevelgit-ayunz5ovfuv ws-us121 gitpod io_events_" src="https://github.com/user-attachments/assets/b4388d71-227d-44a9-b6fd-e2b3b8cca652" />
<img width="2146" height="3450" alt="4000-armanbilge-typelevelgit-ayunz5ovfuv ws-us121 gitpod io_event_2025-08-meetup-lausanne_" src="https://github.com/user-attachments/assets/019744e7-bdca-490b-8eff-a084e1636576" />
</details>