### PR TITLE
Bump protosearch, fixing query perf

### DIFF
--- a/build.scala
+++ b/build.scala
@@ -4,7 +4,7 @@
 //> using dep org.graalvm.js:js:25.0.2
 //> using dep org.webjars.npm:katex:0.16.28
 //> using dep org.webjars.npm:fortawesome__fontawesome-free:7.1.0
-//> using dep pink.cozydev::protosearch-laika:0.0-c89fb9e-SNAPSHOT
+//> using dep pink.cozydev::protosearch-laika:0.0-fa9dd83-SNAPSHOT
 //> using repository https://central.sonatype.com/repository/maven-snapshots
 //> using option -deprecation
 


### PR DESCRIPTION
Previously we were running into performance issues for "large" prefix queries.
When I user types `fs2 S`, perhaps on their way to typing `fs2 Stream`, we rewrite this query to `fs2 (S OR S*)`.
This means we end up with something like `fs2 OR S OR ....every term in the whole collection starting with S...`, this can be quite large.

One approach to addressing this, that we likely should still do, is to debounce search on input.
However, the javascript to do this was escaping me.
So I opted to improve the performance of `fs2 S` [upstream](https://github.com/cozydev-pink/protosearch/pull/346) by 135x for now 😆 😬 