### PR TITLE
Render math in RSS with MathML

### DIFF
--- a/build.scala
+++ b/build.scala
@@ -452,6 +452,7 @@ object KaTeX {
       output: String = "htmlAndMathml"
   ): String =
     synchronized {
+      // https://katex.org/docs/options
       val options = Map(
         "throwOnError" -> true,
         "strict" -> true,


### PR DESCRIPTION
Closes https://github.com/typelevel/typelevel.github.com/issues/149.

My RSS reader appears to support MathML. To make this work, needed a couple tweaks:
1. When rendering to RSS, disable KaTeX's HTML output in favor of MathML.
2. Because the RSS renderer secretly delegates to the HTML renderer, we need a bit of trickery to get the correct content to render.