### PR TITLE
Add RSS to footer

### DIFF
--- a/src/templates/footer.template.html
+++ b/src/templates/footer.template.html
@@ -41,6 +41,10 @@
         href="https://linkedin.com/company/typelevel-foundation">
         @:svg(fa-linkedin)
       </a>
+      <a class="bulma-icon bulma-is-large bulma-has-text-current"
+        href="@:target(/blog/feed.rss)">
+        @:svg(fa-square-rss)
+      </a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Closes https://github.com/typelevel/typelevel.github.com/issues/399.

<img width="442" height="94" alt="Screenshot 2026-02-18 at 10 04 20 PM" src="https://github.com/user-attachments/assets/349c6481-01ac-4b3b-8f46-2c6c3e2e9f08" />

Alternatively we could use this RSS icon:
https://fontawesome.com/icons/rss?f=classic&s=solid