### PR TITLE
Refresh security.txt

### DIFF
--- a/src/.well-known/security.txt
+++ b/src/.well-known/security.txt
@@ -2,16 +2,17 @@
 Hash: SHA512
 
 Contact: mailto:security@typelevel.org
-Expires: 2026-02-19T02:39Z
+Expires: 2026-02-24T17:55:33Z
 Encryption: openpgp4fpr:904c153733dbb0106915c0bd975be5bc29d92ca5
 Encryption: openpgp4fpr:1cae49948ee0a2d7154a2b62a335b107e9282548
 Preferred-Languages: en
 Canonical: https://typelevel.org/.well-known/security.txt
 Policy: https://github.com/typelevel/.github/blob/main/SECURITY.md
+
 -----BEGIN PGP SIGNATURE-----
 
-iIwEARYKADQWIQQUykrE/bANX4J6vAxZhkimXfZFBgUCZ7VK6BYcbm9yZXBseUB0
-eXBlbGV2ZWwub3JnAAoJEFmGSKZd9kUGRb0BAPhyXJCoTtFNGaxjjL+m7j/8ein2
-j4barWRaFQqbXfnnAP4oFYY4hRVOEzLPoU0CNPh0BT2sPUUp1lXwPjf7YS47CQ==
-=Ca5d
+iHUEARYKAB0WIQTY2Ob6IordWLkPvQodLvmkIR+xCwUCaZ3mSwAKCRAdLvmkIR+x
+CwtdAQCg9pJAT+YcW16FLIDwydO1SGq7OjlQKzO6GzAEbpCf3gEAqT4Gu7lfmBJU
+Lh5Z2yYhozpFekj9Ylikd7ISK+R5Hgg=
+=UJKY
 -----END PGP SIGNATURE-----


### PR DESCRIPTION
I no longer have access to the shared Typelevel GPG private key, so this is signed by me.  A key could be created for signing on behalf of the security team, but then credible keys would need to sign _that_.

Fixes #588.  Does _not_ fix the 404 on the file.  I don't know how Laika handles those. 