### PR TITLE
Explicitly add `.well-known` to input tree

### DIFF
--- a/build.scala
+++ b/build.scala
@@ -87,6 +87,8 @@ object LaikaBuild {
 
     InputTree[IO]
       .addDirectory("src")
+      // Laika skips .dotfiles by default
+      .addDirectory("src/.well-known", Path.Root / ".well-known")
       .addInputStream(
         IO.blocking(securityPolicy.openStream()),
         Path.Root / "security.md"


### PR DESCRIPTION
Fixes the 404 noted in https://github.com/typelevel/typelevel.github.com/pull/601.