### PR TITLE
Add getting started pages

### DIFF
--- a/src/community/README.md
+++ b/src/community/README.md
@@ -24,3 +24,11 @@ Typelevel boasts an impressive ecosystem of affiliate projects, built by our com
 @:fragment(coc)
 The Typelevel community is dedicated to providing a positive experience for everyone. Whether you are new or familiar with our community, we care about making it a welcoming and safe place for you and we are here to support you.
 @:@
+
+@:fragment(contributing)
+Learn how to get involved in Typelevel projects. Find good first issues, understand the workflow, and collaborate with maintainers.
+@:@
+
+@:fragment(resources)
+Explore recommended books, courses, and documentation for learning functional programming in Scala and the Typelevel ecosystem.
+@:@

--- a/src/community/about.template.html
+++ b/src/community/about.template.html
@@ -72,7 +72,7 @@
       <div class="bulma-card bulma-has-background-info-95">
         <div class="bulma-card-content bulma-has-text-centered">
           <span class="bulma-icon bulma-large bulma-has-text-info bulma-is-large bulma-is-size-3">
-            @:svg(fa-code-branch)
+            @:svg(fa-puzzle-piece)
           </span>
           <h4 class="bulma-is-4 bulma-has-text-info-20">Start Contributing</h4>
           <div class="bulma-content bulma-has-text-left hyphenate">
@@ -88,7 +88,7 @@
       <div class="bulma-card bulma-has-background-link-95">
         <div class="bulma-card-content bulma-has-text-centered">
           <span class="bulma-icon bulma-large bulma-has-text-link bulma-is-large bulma-is-size-3">
-            @:svg(fa-book)
+            @:svg(fa-person-chalkboard)
           </span>
           <h4 class="bulma-is-4 bulma-has-text-link-20">Learning Resources</h4>
           <div class="bulma-content bulma-has-text-left hyphenate">

--- a/src/community/about.template.html
+++ b/src/community/about.template.html
@@ -68,6 +68,38 @@
         </div>
       </div>
     </div>
+    <div class="bulma-column bulma-is-6-tablet bulma-is-12-mobile">
+      <div class="bulma-card bulma-has-background-info-95">
+        <div class="bulma-card-content bulma-has-text-centered">
+          <span class="bulma-icon bulma-large bulma-has-text-info bulma-is-large bulma-is-size-3">
+            @:svg(fa-code-branch)
+          </span>
+          <h4 class="bulma-is-4 bulma-has-text-info-20">Start Contributing</h4>
+          <div class="bulma-content bulma-has-text-left hyphenate">
+            ${cursor.currentDocument.fragments.contributing}
+          </div>
+          <a class="bulma-button bulma-is-info" href="@:target(start-contributing.md)">
+            Learn How
+          </a>
+        </div>
+      </div>
+    </div>
+    <div class="bulma-column bulma-is-6-tablet bulma-is-12-mobile">
+      <div class="bulma-card bulma-has-background-link-95">
+        <div class="bulma-card-content bulma-has-text-centered">
+          <span class="bulma-icon bulma-large bulma-has-text-link bulma-is-large bulma-is-size-3">
+            @:svg(fa-book)
+          </span>
+          <h4 class="bulma-is-4 bulma-has-text-link-20">Learning Resources</h4>
+          <div class="bulma-content bulma-has-text-left hyphenate">
+            ${cursor.currentDocument.fragments.resources}
+          </div>
+          <a class="bulma-button bulma-is-link" href="@:target(learning-resources.md)">
+            View Resources
+          </a>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 @:@

--- a/src/community/learning-resources.md
+++ b/src/community/learning-resources.md
@@ -1,0 +1,38 @@
+
+#  Learning Resources
+
+This is a collection of community recommended resources for functional programming in Scala and materials that help contributors understand the ideas behind Typelevel libraries.
+
+> These resources are optional. You can start contributing with good first issues or examples and learn more as you go!
+
+## Foundational books & guides
+
+- **[Functional Programming in Scala](https://www.manning.com/books/functional-programming-in-scala-second-edition)**: A classic introduction to FP ideas in Scala; strong on the thinking behind libraries like Cats.  
+
+- **[Scala with Cats](https://scalawithcats.com)**:  Practical introduction to Cats
+
+- **[Essential Scala](https://underscore.io/books/essential-scala/)**: A functionally-friendly introduction to Scala language features. 
+
+- **[Creative Scala](https://www.creativescala.org/creative-scala/)**: Hands-on exercises and  usage for practising Scala.  
+
+## Documentation for Key Libraries
+
+- **[Cats Effect](https://typelevel.org/cats-effect/)**: Core to the modern Typelevel runtime model.
+  
+- **[FS2](https://fs2.io)**: Functional streaming library used throughout the ecosystem.  
+
+- **[http4s](https://http4s.org)**: Functional HTTP toolkit for Scala.  
+
+- **[Circe](https://circe.github.io/circe)**: JSON library for Scala.  
+
+- **[Laika](https://typelevel.org/Laika/)**: Site and E-book Generator and Customizable Text Markup Transformer in Scala
+
+
+## Tutorials & Courses
+
+- Coursera courses [Functional Programming in Scala](https://www.coursera.org/learn/scala-functional-programming) (useful if you prefer lecture-style learning and a systematic introduction).  
+- Community [blog posts](https://typelevel.org/blog/)
+
+## Scala ecosystem docs
+
+- **[Official Scala documentation](https://docs.scala-lang.org/)**: general language reference and guides

--- a/src/community/learning-resources.md
+++ b/src/community/learning-resources.md
@@ -7,13 +7,14 @@ This is a collection of community recommended resources for functional programmi
 
 ## Foundational books & guides
 
-- **[Functional Programming in Scala](https://www.manning.com/books/functional-programming-in-scala-second-edition)**: A classic introduction to FP ideas in Scala; strong on the thinking behind libraries like Cats.  
+- **[Creative Scala](https://www.creativescala.org/creative-scala/)**: Hands-on exercises and  usage for practising Scala.
+
+- **[Essential Scala](https://underscore.io/books/essential-scala/)**: A functionally-friendly introduction to Scala language features.
 
 - **[Scala with Cats](https://scalawithcats.com)**:  Practical introduction to Cats
 
-- **[Essential Scala](https://underscore.io/books/essential-scala/)**: A functionally-friendly introduction to Scala language features. 
+- **[Functional Programming in Scala](https://www.manning.com/books/functional-programming-in-scala-second-edition)**: A classic introduction to FP ideas in Scala; strong on the thinking behind libraries like Cats. 
 
-- **[Creative Scala](https://www.creativescala.org/creative-scala/)**: Hands-on exercises and  usage for practising Scala.  
 
 ## Documentation for Key Libraries
 

--- a/src/community/learning-resources.md
+++ b/src/community/learning-resources.md
@@ -31,7 +31,6 @@ This is a collection of community recommended resources for functional programmi
 ## Tutorials & Courses
 
 - Coursera courses [Functional Programming in Scala](https://www.coursera.org/learn/scala-functional-programming) (useful if you prefer lecture-style learning and a systematic introduction).  
-- Community [blog posts](https://typelevel.org/blog/)
 
 ## Scala ecosystem docs
 

--- a/src/community/start-contributing.md
+++ b/src/community/start-contributing.md
@@ -1,0 +1,39 @@
+
+# Start Contributing to Typelevel
+
+Typelevel projects power a large part of the functional Scala ecosystem. They are also complex, long-lived codebases with active communities. Contributing can feel intimidating at first, but the path in is actually quite simple! A practical path that works well across most Typelevel repositories:
+
+#### Find something that can be improved
+   - Look for open issues, especially those labeled `good first issue` or `help wanted`.
+   - Browse the curated [good-first-issues board](https://github.com/orgs/typelevel/projects/1/)
+   - If you're already using the library, improve something that bothered you.
+   - Documentation and tests are excellent starting points too.
+
+#### Understand the problem first
+   - Read the issue carefully, understand the current implementation.
+   - Look for existing PRs or recent comments
+   - Check whether a solution was already proposed.
+
+#### Communication is Key
+   - Comment on the issue saying you'd like to work on it and briefly describe your idea or approach.
+   - Ask clarifying questions if anything is unclear.
+   - If the change is small, you can open a draft PR early to get feedback.
+
+#### Open a PR and iterate
+   - Fork the repo, create a branch, and implement the change. Add or update tests where appropriate.
+   - Open a PR with a clear description of the problem and your solution. Read the [Typelevel AI policy](https://typelevel.org/gsoc/ai.html).
+   - Expect review feedback, ask questions, adjust your changes, and iterate.
+
+#### Become a User First
+
+Build something small with Cats Effect. Try streaming something with FS2. Use http4s for a simple service. Build with [Typelevel Toolkit](https://typelevel.org/blog/). 
+A common piece of advice from the community is:
+
+> Become a user of the ecosystem you want to contribute to.
+
+#### Where to Ask for Help
+
+- Join the [Typelevel Discord](https://discord.gg/typelevel-632277896739946517)
+- Ask in `#starting-contributing` if you're new to contributing.
+- Use library-specific channels like `#cats`, `#cats-effect`, `#fs2`, or `#http4s` for more focused questions.
+- You can also ask directly on a GitHub issue if your question is specific to that issue.

--- a/src/community/start-contributing.md
+++ b/src/community/start-contributing.md
@@ -1,39 +1,37 @@
 
 # Start Contributing to Typelevel
 
-Typelevel projects power a large part of the functional Scala ecosystem. They are also complex, long-lived codebases with active communities. Contributing can feel intimidating at first, but the path in is actually quite simple! A practical path that works well across most Typelevel repositories:
+Typelevel projects power a large part of the functional Scala ecosystem. They are also complex, long-lived codebases with active communities. Contributing can feel intimidating at first, but the path in is actually quite simple! 
 
-#### Find something that can be improved
-   - Look for open issues, especially those labeled `good first issue` or `help wanted`.
-   - Browse the curated [good-first-issues board](https://github.com/orgs/typelevel/projects/1/)
-   - If you're already using the library, improve something that bothered you.
-   - Documentation and tests are excellent starting points too.
-
-#### Understand the problem first
-   - Read the issue carefully, understand the current implementation.
-   - Look for existing PRs or recent comments
-   - Check whether a solution was already proposed.
-
-#### Communication is Key
-   - Comment on the issue saying you'd like to work on it and briefly describe your idea or approach.
-   - Ask clarifying questions if anything is unclear.
-   - If the change is small, you can open a draft PR early to get feedback.
-
-#### Open a PR and iterate
-   - Fork the repo, create a branch, and implement the change. Add or update tests where appropriate.
-   - Open a PR with a clear description of the problem and your solution. Read the [Typelevel AI policy](https://typelevel.org/gsoc/ai.html).
-   - Expect review feedback, ask questions, adjust your changes, and iterate.
-
-#### Become a User First
-
-Build something small with Cats Effect. Try streaming something with FS2. Use http4s for a simple service. Build with [Typelevel Toolkit](https://typelevel.org/blog/). 
-A common piece of advice from the community is:
+Build something small with Cats Effect. Try streaming something with FS2. Use http4s for a simple service. Build with [Typelevel Toolkit](https://typelevel.org/blog/). Build a static site with Laika.
 
 > Become a user of the ecosystem you want to contribute to.
 
-#### Where to Ask for Help
+Also some tips that works well across most Typelevel repositories:
 
-- Join the [Typelevel Discord](https://discord.gg/typelevel-632277896739946517)
+#### Find something that can be improved
+- Look for open issues, especially those labeled `good first issue` or `help wanted`.
+- Browse the curated [good-first-issues board](https://github.com/orgs/typelevel/projects/1/).
+- If you're already using the library, improve something that bothered you.
+- Documentation and tests are excellent starting points too.
+
+#### Understand the problem first
+- Read the issue carefully, understand the current implementation.
+- Look for existing PRs or recent comments.
+- Check whether a solution was already proposed.
+
+#### Communication is Key
+- Comment on the issue saying you'd like to work on it and briefly describe your idea or approach.
+- Ask clarifying questions if anything is unclear.
+- If the change is small, you can open a draft PR early to get feedback.
+
+#### Open a PR and iterate
+- Fork the repo, create a branch, and implement the change. Add or update tests where appropriate.
+- Open a PR with a clear description of the problem and your solution. Read the [Typelevel AI policy](https://typelevel.org/gsoc/ai.html).
+- Expect review feedback, ask questions, adjust your changes, and iterate.
+
+#### Where to Ask for Help
+- Join the [Typelevel Discord](https://discord.gg/typelevel-632277896739946517).
 - Ask in `#starting-contributing` if you're new to contributing.
 - Use library-specific channels like `#cats`, `#cats-effect`, `#fs2`, or `#http4s` for more focused questions.
 - You can also ask directly on a GitHub issue if your question is specific to that issue.

--- a/src/community/start-contributing.md
+++ b/src/community/start-contributing.md
@@ -27,7 +27,7 @@ Also some tips that works well across most Typelevel repositories:
 
 #### Open a PR and iterate
 - Fork the repo, create a branch, and implement the change. Add or update tests where appropriate.
-- Open a PR with a clear description of the problem and your solution. Read the [Typelevel AI policy](https://typelevel.org/gsoc/ai.html).
+- Open a PR with a clear description of the problem and your solution.
 - Expect review feedback, ask questions, adjust your changes, and iterate.
 
 #### Where to Ask for Help

--- a/src/community/start-contributing.md
+++ b/src/community/start-contributing.md
@@ -3,7 +3,7 @@
 
 Typelevel projects power a large part of the functional Scala ecosystem. They are also complex, long-lived codebases with active communities. Contributing can feel intimidating at first, but the path in is actually quite simple! 
 
-Build something small with Cats Effect. Try streaming something with FS2. Use http4s for a simple service. Build with [Typelevel Toolkit](https://typelevel.org/blog/). Build a static site with Laika.
+Build something small with Cats Effect. Try streaming something with FS2. Use http4s for a simple service. Build with [Typelevel Toolkit](https://typelevel.org/toolkit/). Build a static site with Laika.
 
 > Become a user of the ecosystem you want to contribute to.
 


### PR DESCRIPTION
Fixes #590

Added two new pages under `src/community/`:

1.Start Contributing: outlines the typical contribution workflow across Typelevel projects, including issue selection (good-first-issue board), communication norms, PR process (included the AI policy), and Discord channels for help
2.Learning Resources: collects community recommended books, courses, and documentation for functional programming in Scala and key Typelevel libraries

Updated the community landing page template `about.template.html` to include two additional cards, along with corresponding fragments in `community/README.md`. The new pages follow the existing community  pagelayout and template structure. 

Used AI for formatting markdown & proofreading but I wrote the content itself, with help of past resources & recommendations found in various discord channels

example (learning resource page):
<img width="1728" height="873" alt="image" src="https://github.com/user-attachments/assets/29828799-60be-4a7a-b320-99e1ac9ae2e1" />
additional cards in community page:

<img width="1655" height="758" alt="image" src="https://github.com/user-attachments/assets/07c5a22a-bea5-47a6-94b5-a577226dd9fa" />
