### PR TITLE
Add WebJar class for accessing WebJar files

### DIFF
--- a/build.scala
+++ b/build.scala
@@ -405,13 +405,9 @@ object LaikaCustomizations {
   }
 
   val Icons = {
-    def loadFaIcon(prefix: String, name: String) = {
-      val resourcePath =
-        "/META-INF/resources/webjars/fortawesome__fontawesome-free/7.2.0"
-      val inputStream =
-        getClass.getResourceAsStream(s"$resourcePath/svgs/$prefix/$name.svg")
-      String(inputStream.readAllBytes())
-    }
+    val fa = WebJar("fortawesome__fontawesome-free")
+    def loadFaIcon(prefix: String, name: String) =
+      fa.load(s"svgs/$prefix/$name.svg")
 
     Map(
       // brands
@@ -439,11 +435,9 @@ object KaTeX {
   import org.graalvm.polyglot.*
   import scala.jdk.CollectionConverters.*
 
-  private def loadKaTeX(): String = {
-    val resourcePath = "/META-INF/resources/webjars/katex/0.16.44/dist/katex.js"
-    val inputStream = getClass.getResourceAsStream(resourcePath)
-    String(inputStream.readAllBytes())
-  }
+  private val katexJar = WebJar("katex")
+
+  private def loadKaTeX(): String = katexJar.load("dist/katex.js")
 
   private lazy val katex = {
     val ctx = Context
@@ -474,6 +468,36 @@ object KaTeX {
       }
     }
 
+}
+
+// Provides access to resources of a bundled WebJar.
+class WebJar(artifactId: String) {
+  private val version: String =
+    val propsPath = s"META-INF/maven/org.webjars.npm/$artifactId/pom.properties"
+    val stream = Thread
+      .currentThread()
+      .getContextClassLoader
+      .getResourceAsStream(propsPath)
+    if stream == null then
+      throw IllegalStateException(
+        s"Could not find pom.properties for webjar '$artifactId' on the classpath."
+      )
+    val props = java.util.Properties()
+    props.load(stream)
+    props.getProperty("version")
+
+  // Load a resource from this WebJar as a String, uses relative paths.
+  def load(path: String): String =
+    val resourcePath = s"META-INF/resources/webjars/$artifactId/$version/$path"
+    val stream = Thread
+      .currentThread()
+      .getContextClassLoader
+      .getResourceAsStream(resourcePath)
+    if stream == null then
+      throw IllegalStateException(
+        s"Could not find resource '$path' in webjar '$artifactId' ($version)."
+      )
+    String(stream.readAllBytes())
 }
 
 object Redirects {

--- a/build.scala
+++ b/build.scala
@@ -472,13 +472,14 @@ object KaTeX {
 
 // Provides access to resources of a bundled WebJar.
 class WebJar(artifactId: String) {
+  import java.io.FileNotFoundException
   private val classLoader = classOf[WebJar].getClassLoader
 
   private val version: String =
     val propsPath = s"META-INF/maven/org.webjars.npm/$artifactId/pom.properties"
     val stream = classLoader.getResourceAsStream(propsPath)
     if stream == null then
-      throw IllegalStateException(
+      throw FileNotFoundException(
         s"Could not find pom.properties for webjar '$artifactId' on the classpath."
       )
     val props = java.util.Properties()
@@ -490,7 +491,7 @@ class WebJar(artifactId: String) {
     val resourcePath = s"META-INF/resources/webjars/$artifactId/$version/$path"
     val stream = classLoader.getResourceAsStream(resourcePath)
     if stream == null then
-      throw IllegalStateException(
+      throw FileNotFoundException(
         s"Could not find resource '$path' in webjar '$artifactId' ($version)."
       )
     String(stream.readAllBytes())

--- a/build.scala
+++ b/build.scala
@@ -472,12 +472,11 @@ object KaTeX {
 
 // Provides access to resources of a bundled WebJar.
 class WebJar(artifactId: String) {
+  private val classLoader = classOf[WebJar].getClassLoader
+
   private val version: String =
     val propsPath = s"META-INF/maven/org.webjars.npm/$artifactId/pom.properties"
-    val stream = Thread
-      .currentThread()
-      .getContextClassLoader
-      .getResourceAsStream(propsPath)
+    val stream = classLoader.getResourceAsStream(propsPath)
     if stream == null then
       throw IllegalStateException(
         s"Could not find pom.properties for webjar '$artifactId' on the classpath."
@@ -489,10 +488,7 @@ class WebJar(artifactId: String) {
   // Load a resource from this WebJar as a String, uses relative paths.
   def load(path: String): String =
     val resourcePath = s"META-INF/resources/webjars/$artifactId/$version/$path"
-    val stream = Thread
-      .currentThread()
-      .getContextClassLoader
-      .getResourceAsStream(resourcePath)
+    val stream = classLoader.getResourceAsStream(resourcePath)
     if stream == null then
       throw IllegalStateException(
         s"Could not find resource '$path' in webjar '$artifactId' ($version)."


### PR DESCRIPTION
Closes https://github.com/typelevel/typelevel.github.com/issues/633

There's basically two features of this work:
- We only need to specify the WebJar version once in the `using dep` directive, this makes manually bumping easier.
- We reduce the boilerplate of loading a file from a WebJar

---

Felt weird doing all this without fs2 or IO, but so far none of our uses of this are in IO.
The whole `org.graalvm.polyglot.Context` stuff feels like it could have a cool little micro library around it.