### PR TITLE
Update protosearch, exclude the 404 page

### DIFF
--- a/build.scala
+++ b/build.scala
@@ -80,8 +80,9 @@ object LaikaBuild {
   import pink.cozydev.protosearch.laika.IndexConfig
   import pink.cozydev.protosearch.ui.SearchUI
 
+  val indexExclusions = Path.Root / "404.md" +: Redirects.paths
   val indexConfig =
-    IndexConfig.withExcludedPaths(Path.Root / "404.md")
+    IndexConfig.withExcludedPaths(indexExclusions*)
 
   def input = {
     val securityPolicy = new URI(
@@ -490,6 +491,8 @@ object Redirects {
   def inputTree = map.foldLeft(InputTree[IO]) { case (tree, (from, to)) =>
     tree.addString(mkRedirect(to), Root / (from.stripSuffix(".html") + ".md"))
   }
+
+  def paths = map.keys.map(p => Root / p.stripSuffix(".html")).toList
 
   private def mkRedirect(to: String) =
     s"""{% laika.html.template = "/templates/redirect.template.html", laika.targetFormats: [html], target = "$to" %}"""

--- a/build.scala
+++ b/build.scala
@@ -4,7 +4,7 @@
 //> using dep org.graalvm.js:js:25.0.2
 //> using dep org.webjars.npm:katex:0.16.44
 //> using dep org.webjars.npm:fortawesome__fontawesome-free:7.2.0
-//> using dep pink.cozydev::protosearch-laika:0.0-7f79720-SNAPSHOT
+//> using dep pink.cozydev::protosearch-laika:0.0-bbb1740-SNAPSHOT
 //> using repository https://central.sonatype.com/repository/maven-snapshots
 //> using option -deprecation
 
@@ -77,8 +77,11 @@ object LaikaBuild {
   import laika.io.syntax.*
   import laika.parse.code.languages.ScalaSyntax
   import laika.theme.*
-  import pink.cozydev.protosearch.analysis.{IndexFormat, IndexRendererConfig}
+  import pink.cozydev.protosearch.laika.IndexConfig
   import pink.cozydev.protosearch.ui.SearchUI
+
+  val indexConfig =
+    IndexConfig.withExcludedPaths(Path.Root / "404.md")
 
   def input = {
     val securityPolicy = new URI(
@@ -128,7 +131,7 @@ object LaikaBuild {
     .build
 
   val binaryRenderers = List(
-    IndexRendererConfig(true),
+    indexConfig.config,
     BinaryRendererConfig(
       "rss",
       LaikaCustomizations.Rss,
@@ -154,7 +157,7 @@ object LaikaBuild {
       .parallel[IO]
       .build
     val index =
-      Renderer.of(IndexFormat).withConfig(parser.config).parallel[IO].build
+      Renderer.of(indexConfig.format).withConfig(parser.config).parallel[IO].build
 
     (html, rss, index).tupled.use { (html, rss, index) =>
       parser.fromInput(input).parse.flatMap { tree =>

--- a/build.scala
+++ b/build.scala
@@ -157,7 +157,11 @@ object LaikaBuild {
       .parallel[IO]
       .build
     val index =
-      Renderer.of(indexConfig.format).withConfig(parser.config).parallel[IO].build
+      Renderer
+        .of(indexConfig.format)
+        .withConfig(parser.config)
+        .parallel[IO]
+        .build
 
     (html, rss, index).tupled.use { (html, rss, index) =>
       parser.fromInput(input).parse.flatMap { tree =>

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ function hideSearchModal() {
 }
 
 function renderHit(hit) {
-  const link = `${hit.fields.path}.html`
+  const link = `/${hit.fields.path}.html`
   const title = hit.highlights["title"] || hit.fields["title"]
   const preview = hit.highlights["body"]
   const tags = []


### PR DESCRIPTION
Updates to latest protosearch snapshot, which let's us exclude paths and specify our config just once.


**Excluding the 404 page**

Before:
<img width="691" height="307" alt="image" src="https://github.com/user-attachments/assets/37c13525-0318-495f-8633-4ba32a8136bb" />

After:
<img width="686" height="328" alt="image" src="https://github.com/user-attachments/assets/a88b6c99-92d4-496d-b4bf-d2eedc42aec1" />
