### PR TITLE
Remove time zone from calendar iframe

### DIFF
--- a/src/community/meetups.md
+++ b/src/community/meetups.md
@@ -9,7 +9,7 @@ To receive notifications of future meetups subscribe to the calendar below or as
 @:html
 <figure class="bulma-image bulma-is-4by3">
   <iframe
-    src="https://calendar.google.com/calendar/embed?src=c_4107a1cfc2da0c1425c057ff4ba248f3378e4d3ad3e6bf39e79b08ad895bf94d%40group.calendar.google.com&ctz=America%2FLos_Angeles"
+    src="https://calendar.google.com/calendar/embed?src=c_4107a1cfc2da0c1425c057ff4ba248f3378e4d3ad3e6bf39e79b08ad895bf94d%40group.calendar.google.com"
     style="border: 0" width="100%" height="100%" frameborder="0" scrolling="no"></iframe>
 </figure>
 @:@


### PR DESCRIPTION
So then I think it will render in the viewer's local timezone instead.