### PR TITLE
Update Start Contributing Guide and Community pages

### DIFF
--- a/src/community/README.md
+++ b/src/community/README.md
@@ -26,9 +26,9 @@ The Typelevel community is dedicated to providing a positive experience for ever
 @:@
 
 @:fragment(contributing)
-Learn how to get involved in Typelevel projects. Find good first issues, understand the workflow, and collaborate with maintainers.
+The projects in the Typelevel ecosystem are all open-source. Learn how to contribute to Typelevel and help maintain your favorite projects. Find good first issues, understand the workflow, and collaborate with maintainers.
 @:@
 
 @:fragment(resources)
-Explore recommended books, courses, and documentation for learning functional programming in Scala and the Typelevel ecosystem.
+Learn functional programming fundamentals and the theory behind the design of Typelevel libraries. Explore recommended books, courses, and documentation for learning functional programming in Scala and the Typelevel ecosystem.
 @:@

--- a/src/community/about.template.html
+++ b/src/community/about.template.html
@@ -1,12 +1,12 @@
 @:embed(/templates/main.template.html)
-<div class="bulma-section bulma-content bulma-container bulma-is-max-desktop">
+<div class="bulma-section bulma-content bulma-container bulma-is-max-fullhd">
 
   ${cursor.currentDocument.content}
 
   <div class="bulma-columns bulma-is-multiline">
-    <div class="bulma-column bulma-is-6-tablet bulma-is-12-mobile">
+    <div class="bulma-column bulma-is-6 bulma-is-12-mobile bulma-is-4-fullhd">
       <div class="bulma-card bulma-has-background-primary-light">
-        <div class="bulma-card-content bulma-has-text-centered">
+        <div class="bulma-card-content bulma-has-text-centered ">
           <span class="bulma-icon bulma-large bulma-has-text-primary bulma-is-large bulma-is-size-3">
             @:svg(fa-discord)
           </span>
@@ -20,7 +20,7 @@
         </div>
       </div>
     </div>
-    <div class="bulma-column bulma-is-6-tablet bulma-is-12-mobile">
+    <div class="bulma-column bulma-is-6 bulma-is-12-mobile bulma-is-4-fullhd">
       <div class="bulma-card bulma-has-background-warning-95">
         <div class="bulma-card-content bulma-has-text-centered">
           <span class="bulma-icon bulma-large bulma-has-text-warning bulma-is-large bulma-is-size-3">
@@ -36,13 +36,13 @@
         </div>
       </div>
     </div>
-    <div class="bulma-column bulma-is-6-tablet bulma-is-12-mobile">
+    <div class="bulma-column bulma-is-6 bulma-is-12-mobile bulma-is-4-fullhd">
       <div class="bulma-card bulma-has-background-success-95">
         <div class="bulma-card-content bulma-has-text-centered">
           <span class="bulma-icon bulma-large bulma-has-text-success bulma-is-large bulma-is-size-3">
             @:svg(fa-puzzle-piece)
           </span>
-          <h4 class="bulma-is-4 bulma-has-text-success-20">Affiliate Projects</h4>
+          <h4 class="bulma-is-4 bulma-has-text-success-20">Explore Projects</h4>
           <div class="bulma-content bulma-has-text-left hyphenate">
             ${cursor.currentDocument.fragments.projects}
           </div>
@@ -52,23 +52,7 @@
         </div>
       </div>
     </div>
-    <div class="bulma-column bulma-is-6-tablet bulma-is-12-mobile">
-      <div class="bulma-card bulma-has-background-danger-95">
-        <div class="bulma-card-content bulma-has-text-centered">
-          <span class="bulma-icon bulma-large bulma-has-text-danger bulma-is-large bulma-is-size-3">
-            @:svg(fa-hand-holding-heart)
-          </span>
-          <h4 class="bulma-is-4 bulma-has-text-danger-20">Code of Conduct</h4>
-          <div class="bulma-content bulma-has-text-left hyphenate">
-            ${cursor.currentDocument.fragments.coc}
-          </div>
-          <a class="bulma-button bulma-is-danger bulma-has-text-light" href="@:target(/code-of-conduct/README.md)">
-            Read the Code of Conduct
-          </a>
-        </div>
-      </div>
-    </div>
-    <div class="bulma-column bulma-is-6-tablet bulma-is-12-mobile">
+    <div class="bulma-column bulma-is-6 bulma-is-12-mobile bulma-is-4-fullhd">
       <div class="bulma-card bulma-has-background-info-95">
         <div class="bulma-card-content bulma-has-text-centered">
           <span class="bulma-icon bulma-large bulma-has-text-info bulma-is-large bulma-is-size-3">
@@ -84,7 +68,7 @@
         </div>
       </div>
     </div>
-    <div class="bulma-column bulma-is-6-tablet bulma-is-12-mobile">
+    <div class="bulma-column bulma-is-6 bulma-is-12-mobile bulma-is-4-fullhd">
       <div class="bulma-card bulma-has-background-link-95">
         <div class="bulma-card-content bulma-has-text-centered">
           <span class="bulma-icon bulma-large bulma-has-text-link bulma-is-large bulma-is-size-3">
@@ -96,6 +80,22 @@
           </div>
           <a class="bulma-button bulma-is-link" href="@:target(learning-resources.md)">
             View Resources
+          </a>
+        </div>
+      </div>
+    </div>
+    <div class="bulma-column bulma-is-6 bulma-is-12-mobile bulma-is-4-fullhd">
+      <div class="bulma-card bulma-has-background-danger-95">
+        <div class="bulma-card-content bulma-has-text-centered">
+          <span class="bulma-icon bulma-large bulma-has-text-danger bulma-is-large bulma-is-size-3">
+            @:svg(fa-hand-holding-heart)
+          </span>
+          <h4 class="bulma-is-4 bulma-has-text-danger-20">Code of Conduct</h4>
+          <div class="bulma-content bulma-has-text-left hyphenate">
+            ${cursor.currentDocument.fragments.coc}
+          </div>
+          <a class="bulma-button bulma-is-danger bulma-has-text-light" href="@:target(/code-of-conduct/README.md)">
+            Read the Code of Conduct
           </a>
         </div>
       </div>

--- a/src/community/start-contributing.md
+++ b/src/community/start-contributing.md
@@ -1,37 +1,42 @@
 
 # Start Contributing to Typelevel
 
-Typelevel projects power a large part of the functional Scala ecosystem. They are also complex, long-lived codebases with active communities. Contributing can feel intimidating at first, but the path in is actually quite simple! 
+Typelevel projects power a large part of the functional Scala ecosystem. They are also complex, long-lived codebases with active communities. Contributing can feel intimidating at first, but even bug reports, small fixes, and documentation updates help move our projects forward!
 
-Build something small with Cats Effect. Try streaming something with FS2. Use http4s for a simple service. Build with [Typelevel Toolkit](https://typelevel.org/toolkit/). Build a static site with Laika.
 
-> Become a user of the ecosystem you want to contribute to.
+**Become a user of the ecosystem you want to contribute to.**
 
-Also some tips that works well across most Typelevel repositories:
+- Use the [Typelevel Toolkit](https://typelevel.org/toolkit/) to experiment with [Cats](https://typelevel.org/cats) and [Cats Effect](https://typelevel.org/cats-effect/). 
+- Try streaming something with [FS2](https://fs2.io/#/). 
+- Use [http4s](https://http4s.org/) for a simple service. 
+- Build a static site with [Laika](https://typelevel.org/Laika).
 
-#### Find something that can be improved
+
+**Find something that can be improved**
 - Look for open issues, especially those labeled `good first issue` or `help wanted`.
 - Browse the curated [good-first-issues board](https://github.com/orgs/typelevel/projects/1/).
 - If you're already using the library, improve something that bothered you.
 - Documentation and tests are excellent starting points too.
 
-#### Understand the problem first
+**Understand the problem**
 - Read the issue carefully, understand the current implementation.
 - Look for existing PRs or recent comments.
 - Check whether a solution was already proposed.
 
-#### Communication is Key
+**Communication with the community**
 - Comment on the issue saying you'd like to work on it and briefly describe your idea or approach.
 - Ask clarifying questions if anything is unclear.
 - If the change is small, you can open a draft PR early to get feedback.
 
-#### Open a PR and iterate
+**Open a PR and iterate**
 - Fork the repo, create a branch, and implement the change. Add or update tests where appropriate.
 - Open a PR with a clear description of the problem and your solution.
 - Expect review feedback, ask questions, adjust your changes, and iterate.
 
-#### Where to Ask for Help
+## Where to Ask for Help
 - Join the [Typelevel Discord](https://discord.gg/typelevel-632277896739946517).
 - Ask in `#starting-contributing` if you're new to contributing.
 - Use library-specific channels like `#cats`, `#cats-effect`, `#fs2`, or `#http4s` for more focused questions.
 - You can also ask directly on a GitHub issue if your question is specific to that issue.
+
+> **Note:** This guide emphasises learning and understanding. While most Typelevel projects accept AI written contributions, simply using such tools to fix a bug does not help you learn the codebase and gain the understanding needed to make more significant contributions.


### PR DESCRIPTION
@abby-ql , I pulled out a few more updates I was making to the start contributing page to it's own PR while I finish off the rest of my work. 

Later this week I'll have another PR with more detailed contributing guidelines covering details like copyright and other stuff the GSoC guidelines had, but they're quite separate from these updates.

### reorganized the community page

- make layout take up move space on wide screens. Same behavior on smaller screens. With the pages already having 'columns' letting it take up a bit more space saves users on large monitors having to scroll as much to see everything.
- expand descriptions, so the new sections are similar sized to the others
- move new sections ahead of coc. I like resources and code of conduct last, since they're not quite get involved pages like the others

> [!NOTE]
> I feel there should be a way to template the community page instead of having to update all these css classes, but I didn't want to go down a bikeshedding rabbit-hole.

<img width="1470" alt="community page" src="https://github.com/user-attachments/assets/98275856-e09b-4548-8ce8-53bfb3f3eec9" />

### tweaks to the start contributing guide

- don't say it's simple, it's a phrase that tends to make newcomers assume the opposite. 
- I added links to all the suggestions and put them as a 'Become a user of the ecosystem you want to contribute to.' section
- use bold instead of incorrect subheading levels. 
- add AI note

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/e9af6f0f-331a-44bd-94b9-821465bfa966" />


