### PR TITLE
Add branch previews of the website with cleanup on merge/close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,20 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['**']
+    branches: ["**"]
+    types: [opened, synchronize, reopened, closed]
   push:
-    branches: ['main']
+    branches: ["main"]
+
+env:
+  BRANCH_NAME: pr-${{ github.event.pull_request.number }}
+  CLOUDFLARE_PAGES_PROJECT_NAME: typelevel-website
 
 jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -22,9 +28,55 @@ jobs:
           scala-cli-version: 1.12.2
       - run: scala-cli fmt --check .
       - run: scala-cli --server=false build.scala
+      - name: Publish to Cloudflare Pages
+        if: github.event_name == 'pull_request' && github.event.pull_request.merged != true
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy ./target --project-name=${{ env.CLOUDFLARE_PAGES_PROJECT_NAME }} --branch=${{ env.BRANCH_NAME }}
       - if: github.event_name != 'pull_request'
         uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: target
           cname: typelevel.org
+
+  cleanup-preview:
+    name: Delete Cloudflare Pages preview deployments
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    steps:
+      - name: Delete deployments for this PR's branch
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+
+          API="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT_NAME/deployments"
+          AUTH_HEADER="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+
+          page=1
+          ids=()
+          while :; do
+            response=$(curl -sf -H "$AUTH_HEADER" "$API?page=$page&per_page=25")
+            count=$(echo "$response" | jq '.result | length')
+            [ "$count" -eq 0 ] && break
+            while IFS= read -r id; do
+              ids+=("$id")
+            done < <(echo "$response" | jq -r --arg branch "$BRANCH_NAME" \
+              '.result[] | select(.deployment_trigger.metadata.branch == $branch) | .id')
+            page=$((page + 1))
+          done
+
+          if [ ${#ids[@]} -eq 0 ]; then
+            echo "No preview deployments found for branch $BRANCH_NAME"
+            exit 0
+          fi
+
+          for id in "${ids[@]}"; do
+            echo "Deleting deployment $id"
+            curl -sf -X DELETE -H "$AUTH_HEADER" "$API/$id?force=true"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,13 @@ name: Continuous Integration
 on:
   pull_request:
     branches: ["**"]
-    types: [opened, synchronize, reopened, closed]
   push:
     branches: ["main"]
-
-env:
-  BRANCH_NAME: pr-${{ github.event.pull_request.number }}
-  CLOUDFLARE_PAGES_PROJECT_NAME: typelevel-website
 
 jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -28,55 +22,29 @@ jobs:
           scala-cli-version: 1.12.2
       - run: scala-cli fmt --check .
       - run: scala-cli --server=false build.scala
-      - name: Publish to Cloudflare Pages
-        if: github.event_name == 'pull_request' && github.event.pull_request.merged != true
-        uses: cloudflare/wrangler-action@v4
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+      - name: Upload site artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          command: pages deploy ./target --project-name=${{ env.CLOUDFLARE_PAGES_PROJECT_NAME }} --branch=${{ env.BRANCH_NAME }}
-      - if: github.event_name != 'pull_request'
+          name: site
+          path: target
+          if-no-files-found: error
+          retention-days: 30
+      - name: Upload PR number artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          path: pr_number.txt
+          if-no-files-found: error
+          retention-days: 30
+      - name: Publish to GitHub Pages
+        if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: target
           cname: typelevel.org
-
-  cleanup-preview:
-    name: Delete Cloudflare Pages preview deployments
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    steps:
-      - name: Delete deployments for this PR's branch
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          set -euo pipefail
-
-          API="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT_NAME/deployments"
-          AUTH_HEADER="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
-
-          page=1
-          ids=()
-          while :; do
-            response=$(curl -sf -H "$AUTH_HEADER" "$API?page=$page&per_page=25")
-            count=$(echo "$response" | jq '.result | length')
-            [ "$count" -eq 0 ] && break
-            while IFS= read -r id; do
-              ids+=("$id")
-            done < <(echo "$response" | jq -r --arg branch "$BRANCH_NAME" \
-              '.result[] | select(.deployment_trigger.metadata.branch == $branch) | .id')
-            page=$((page + 1))
-          done
-
-          if [ ${#ids[@]} -eq 0 ]; then
-            echo "No preview deployments found for branch $BRANCH_NAME"
-            exit 0
-          fi
-
-          for id in "${ids[@]}"; do
-            echo "Deleting deployment $id"
-            curl -sf -X DELETE -H "$AUTH_HEADER" "$API/$id?force=true"
-          done

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,50 @@
+name: Cleanup PR Preview
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+env:
+  CLOUDFLARE_PAGES_PROJECT_NAME: typelevel-website
+  BRANCH_NAME: pr-${{ github.event.pull_request.number }}
+
+jobs:
+  cleanup-preview:
+    name: Delete Cloudflare Pages preview deployments
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete deployments for this PR's branch
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+
+          API="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT_NAME/deployments"
+          AUTH_HEADER="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+
+          page=1
+          ids=()
+          while :; do
+            response=$(curl -sf -H "$AUTH_HEADER" "$API?page=$page&per_page=25")
+            count=$(echo "$response" | jq '.result | length')
+            [ "$count" -eq 0 ] && break
+            while IFS= read -r id; do
+              ids+=("$id")
+            done < <(echo "$response" | jq -r --arg branch "$BRANCH_NAME" \
+              '.result[] | select(.deployment_trigger.metadata.branch == $branch) | .id')
+            page=$((page + 1))
+          done
+
+          if [ ${#ids[@]} -eq 0 ]; then
+            echo "No preview deployments found for branch $BRANCH_NAME"
+            exit 0
+          fi
+
+          for id in "${ids[@]}"; do
+            echo "Deleting deployment $id"
+            curl -sf -X DELETE -H "$AUTH_HEADER" "$API/$id?force=true"
+          done

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy PR Preview
+
+on:
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  CLOUDFLARE_PAGES_PROJECT_NAME: typelevel-website
+
+jobs:
+  deploy:
+    name: Publish to Cloudflare Pages
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: site
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download PR number artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          path: .
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Read PR number
+        id: pr
+        run: echo "branch=pr-$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy ./site --project-name=${{ env.CLOUDFLARE_PAGES_PROJECT_NAME }} --branch=${{ steps.pr.outputs.branch }}


### PR DESCRIPTION
This PR allows running branch previews of the website on pull requests, and delete the deployments on merge/close.

This was tested against my personal cloudflare account, both for the creation of the deployment and the cleanup on merge.

The Pages project was setup in the Typelevel cloudflare account, environment variables `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` have already been provisioned with the most minimal scope (Pages: edit) and added to this repo's secrets. I expect this to work as it, but you know, software development.

I studied the alternative of plugging the git repository to the project in the Pages dashboard but it requires using one of the usual static pages project builders. 

It is the first time I actually use Github Actions so feel free to point out things that look weird!

**EDIT: this was updated to use a dual workflow setup: the pr-preview-deploy action that is run will use the version from the main branch even in branches. In PRs we instead simply build and upload the artifact, and let the second workflow (which is safe to run against forks because it cannot be edited) retrieve the artifact and upload it with the secrets.** 