### PR TITLE
Refresh meetups page

### DIFF
--- a/src/community/meetups.md
+++ b/src/community/meetups.md
@@ -1,18 +1,36 @@
-# Virtual Meetups
+# Meetups and Events
 
-Every month, we host a friendly virtual meetup for the Typelevel Community! Each meetup begins with an icebreaker activity to get to know each other, followed by a presentation on a technical topic.
+Our events are a wonderful opportunity to connect with other functional programming enthusiasts in a safe, supportive space. We welcome current and aspiring Typelevel users, contributors, and anyone curious to learn more about functional programming, no matter your prior experience. All of our events follow the [Typelevel Code of Conduct].
 
-Our meetups are open to everyone! All participants must follow the [Typelevel Code of Conduct]. We do not record virtual meetups to respect the privacy of attendees while providing a relaxed, safe space to participate.
-
-To receive notifications of future meetups subscribe to the calendar below or ask to join the [Google Group].
+To receive notifications of future meetups and events, please [follow our Luma calendar][luma].
 
 @:html
-<figure class="bulma-image bulma-is-4by3">
+<figure class="bulma-image bulma-is-3by1">
   <iframe
-    src="https://calendar.google.com/calendar/embed?src=c_4107a1cfc2da0c1425c057ff4ba248f3378e4d3ad3e6bf39e79b08ad895bf94d%40group.calendar.google.com"
-    style="border: 0" width="100%" height="100%" frameborder="0" scrolling="no"></iframe>
+    src="https://luma.com/embed/calendar/cal-8oggABt5UxYo9Ey/events?lt=light"
+    width="100%"
+    height="100%"
+    frameborder="0"
+    style="border: 1px solid #bfcbda88; border-radius: 4px;"
+    allowfullscreen=""
+    aria-hidden="false"
+    tabindex="0"
+  ></iframe>
 </figure>
 @:@
 
+## Virtual Meetups
+
+Every month, we host a friendly virtual meetup for the Typelevel Community! Each meetup begins with an icebreaker activity so we can get to know each other, followed by a presentation on a technical topic. We do not record virtual meetups to respect the privacy of attendees while providing a relaxed, safe space to participate.
+
+## In-person Meetups
+
+We also occasionally organize in-person meetups, such as the [Typelevel Traverse] series.
+
+## Typelevel Summits
+
+We hope to host our next Typelevel Summit in 2027. Recordings of past summits are available on our [YouTube channel](https://www.youtube.com/@typelevel/playlists).
+
 [Typelevel Code of Conduct]: /code-of-conduct/README.md
-[Google Group]: https://groups.google.com/a/typelevel.org/g/meetups
+[Typelevel Traverse]: /blog/traverses-europe-2026.md
+[luma]: https://luma.com/typelevel

--- a/src/community/meetups.md
+++ b/src/community/meetups.md
@@ -1,23 +1,22 @@
 # Meetups and Events
 
-Our events are a wonderful opportunity to connect with other functional programming enthusiasts in a safe, supportive space. We welcome current and aspiring Typelevel users, contributors, and anyone curious to learn more about functional programming, no matter your prior experience. All of our events follow the [Typelevel Code of Conduct].
-
-To receive notifications of future meetups and events, please [follow our Luma calendar][luma].
-
 @:html
-<figure class="bulma-image bulma-is-3by1">
+<figure class="bulma-image bulma-is-4by3 bulma-is-pulled-right bulma-mb-4 event-calendar">
   <iframe
     src="https://luma.com/embed/calendar/cal-8oggABt5UxYo9Ey/events?lt=light"
     width="100%"
     height="100%"
     frameborder="0"
-    style="border: 1px solid #bfcbda88; border-radius: 4px;"
     allowfullscreen=""
     aria-hidden="false"
     tabindex="0"
   ></iframe>
 </figure>
 @:@
+
+Our events are a wonderful opportunity to connect with other functional programming enthusiasts in a safe, supportive space. We welcome current and aspiring Typelevel users, contributors, and anyone curious to learn more about functional programming, no matter your prior experience. All of our events follow the [Typelevel Code of Conduct].
+
+To receive notifications of future meetups and events, please [follow our Luma calendar][luma].
 
 ## Virtual Meetups
 

--- a/src/main.css
+++ b/src/main.css
@@ -117,6 +117,21 @@ img.sponsor {
   hyphens: auto;
 }
 
+.event-calendar {
+  width: 50%;
+  margin-left: 2rem;
+  border-radius: var(--bulma-radius);
+  overflow: hidden;
+}
+
+@media screen and (max-width: 768px) {
+  .event-calendar {
+    float: none !important;
+    width: 100%;
+    margin-left: 0;
+  }
+}
+
 img.legacy-event-sponsor {
   height: 60px;
 }

--- a/src/templates/footer.template.html
+++ b/src/templates/footer.template.html
@@ -7,7 +7,7 @@
     <div class="bulma-column">
       <ul>
         <li><a href="@:target(/projects/README.md)">Project Index</a></li>
-        <li><a href="@:target(/community/meetups.md)">Meetup Calendar</a></li>
+        <li><a href="@:target(/community/meetups.md)">Event Calendar</a></li>
         <li><a href="@:target(/foundation/people.md)">Leadership</a></li>
       </ul>
     </div>

--- a/src/templates/footer.template.html
+++ b/src/templates/footer.template.html
@@ -34,6 +34,12 @@
       <a class="bulma-icon bulma-is-large bulma-has-text-current" href="https://fosstodon.org/@typelevel">
         @:svg(fa-mastodon)
       </a>
+      <a class="bulma-icon bulma-is-large bulma-has-text-current"
+        href="https://luma.com/typelevel">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" aria-hidden="true" style="--fa-width: 1em">
+          <path fill="currentColor" fill-rule="evenodd" d="M163.537 13.343c6.518 3.486 11.634 8.602 15.12 15.12C182.143 34.982 184 41.447 184 59.278v73.444c0 17.83-1.857 24.296-5.343 30.815-3.486 6.518-8.602 11.634-15.12 15.12-6.519 3.486-12.984 5.343-30.815 5.343H59.278c-17.83 0-24.296-1.857-30.815-5.343-6.518-3.486-11.634-8.602-15.12-15.12-3.445-6.442-5.3-12.832-5.342-30.19L8 59.277c0-17.83 1.857-24.295 5.343-30.814s8.602-11.634 15.12-15.12c6.442-3.445 12.832-5.3 30.19-5.342L132.723 8c17.83 0 24.295 1.857 30.814 5.343M96.5 29c0 36.994-29.782 67-66.5 67 36.718 0 66.5 30.006 66.5 67 0-36.994 29.782-67 66.5-67-36.718 0-66.5-30.006-66.5-67"/>
+        </svg>
+      </a>
       <a class="bulma-icon bulma-is-large bulma-has-text-current" href="https://www.youtube.com/@typelevel">
         @:svg(fa-youtube)
       </a>


### PR DESCRIPTION
1. Replace the Google Calendar embed with a Luma Calendar embed.
2. Mention our in-person meetups and summits, in addition to the virtual meetups.

Direct link to meetup page in preview:
https://pr-685.typelevel-website.pages.dev/community/meetups